### PR TITLE
fix(frontend): improve validation and input handling for advance_money field and implement frontend file type validation for uploads

### DIFF
--- a/src/components/travel-requests/CreateTravelRequestForm.tsx
+++ b/src/components/travel-requests/CreateTravelRequestForm.tsx
@@ -48,13 +48,21 @@ const formSchema = z.object({
   priority: z.enum(["alta", "media", "baja"]),
   requirements: z.string().optional(),
   advance_money: z
-    .number()
-    .int()
-    .positive({ message: "El dinero adelantado debe ser positivo" }),
+    .string()
+    .trim()
+    .nonempty({ message: "Este campo es obligatorio" })
+    .regex(/^\d+([.,]\d{1,2})?$/, {
+      message: "Ingresa una cantidad válida con hasta dos decimales",
+    })
+    .refine((value) => Number(value.replace(",", ".")) > 0, {
+      message: "El dinero adelantado debe ser mayor a 0",
+    })
+    .transform((value) => Number(value.replace(",", "."))),
   destinations: z.array(destinationSchema).min(1, "Al menos un destino"),
 });
 
-type RawFormValues = z.infer<typeof formSchema>;
+type FormValues = z.input<typeof formSchema>;
+type SubmitValues = z.output<typeof formSchema>;
 
 function CreateTravelRequestForm() {
   const navigate = useNavigate();
@@ -67,14 +75,14 @@ function CreateTravelRequestForm() {
     handleSubmit,
     formState: { errors },
     reset,
-  } = useForm<RawFormValues>({
+  } = useForm<FormValues, unknown, SubmitValues>({
     resolver: zodResolver(formSchema),
     defaultValues: {
       id_origin_city: null,
       motive: "",
       title: "",
       priority: "media",
-      advance_money: 0,
+      advance_money: "",
       requirements: "",
       destinations: [
         {
@@ -97,7 +105,7 @@ function CreateTravelRequestForm() {
     name: "destinations",
   });
 
-  const onSubmit = async (data: RawFormValues) => {
+  const onSubmit = async (data: SubmitValues) => {
     if (!data.id_origin_city) {
       toast.error("Selecciona una ciudad de origen");
       return;
@@ -123,7 +131,7 @@ function CreateTravelRequestForm() {
 
     const payload = {
       id_origin_city: data.id_origin_city,
-      title: data.motive,
+      title: data.title,
       motive: data.motive,
       requirements: data.requirements || undefined,
       priority: data.priority,
@@ -249,11 +257,46 @@ function CreateTravelRequestForm() {
                 Dinero adelantado (MXN)
               </label>
               <Input
-                type="number"
-                min={1}
-                {...register(`advance_money` as const, {
-                  valueAsNumber: true,
+                type="text"
+                inputMode="decimal"
+                placeholder="0.00"
+                {...register("advance_money", {
+                  onBlur: (e) => {
+                    const value = e.target.value.trim().replace(",", ".");
+
+                    if (!value) return;
+
+                    if (/^\d+(\.\d{1,2})?$/.test(value)) {
+                      e.target.value = Number(value).toFixed(2);
+                    }
+                  },
+                  onChange: (e) => {
+                    let value = e.target.value;
+
+                    value = value.replace(",", ".");
+
+                    // Solo permite números y un punto decimal
+                    value = value.replace(/[^0-9.]/g, "");
+
+                    // Evita más de un punto decimal
+                    const parts = value.split(".");
+                    if (parts.length > 2) {
+                      value = `${parts[0]}.${parts.slice(1).join("")}`;
+                    }
+
+                    // Limita a dos decimales
+                    if (parts[1]?.length > 2) {
+                      value = `${parts[0]}.${parts[1].slice(0, 2)}`;
+                    }
+
+                    e.target.value = value;
+                  },
                 })}
+                onKeyDown={(e) => {
+                  if (["e", "E", "+", "-"].includes(e.key)) {
+                    e.preventDefault();
+                  }
+                }}
               />
               <FieldError msg={errors?.advance_money?.message} />
             </div>

--- a/src/components/travel-requests/TravelRequestForm.tsx
+++ b/src/components/travel-requests/TravelRequestForm.tsx
@@ -63,8 +63,8 @@ const formSchema = z.object({
     .string()
     .trim()
     .nonempty({ message: "Este campo es obligatorio" })
-    .refine((value) => /^\d+(\.\d{1,2})?$/.test(value), {
-      message: "Ingresa una cantidad válida con hasta dos decimales",
+    .refine((value) => /^\d+$/.test(value), {
+      message: "Ingresa un número entero (sin decimales)",
     })
     .refine((value) => Number(value) > 0, {
       message: "El dinero adelantado debe ser mayor a 0",
@@ -320,7 +320,7 @@ function TravelRequestForm({ initialData, requestId }: TravelRequestFormProps) {
       motive: "",
       title: "",
       priority: "media",
-      advance_money: "",
+      advance_money: 0,
       requirements: "",
       requests_destinations: [
         {
@@ -525,35 +525,17 @@ function TravelRequestForm({ initialData, requestId }: TravelRequestFormProps) {
                 </label>
                 <Input
                   id="advance_money"
-                  type="text"
-                  inputMode="decimal"
-                  placeholder="0.00"
+                  type="number"
+                  step="1"
+                  placeholder="0"
                   {...register("advance_money", {
                     onChange: (e) => {
                       let value = e.target.value;
 
-                      value = value.replace(",", ".");
-                      value = value.replace(/[^0-9.]/g, "");
-
-                      const parts = value.split(".");
-                      if (parts.length > 2) {
-                        value = `${parts[0]}.${parts.slice(1).join("")}`;
-                      }
-
-                      if (parts[1]?.length > 2) {
-                        value = `${parts[0]}.${parts[1].slice(0, 2)}`;
-                      }
+                      // solo números enteros
+                      value = value.replace(/[^0-9]/g, "");
 
                       e.target.value = value;
-                    },
-                    onBlur: (e) => {
-                      const value = e.target.value.trim();
-
-                      if (!value) return;
-
-                      if (/^\d+(\.\d{1,2})?$/.test(value)) {
-                        e.target.value = Number(value).toFixed(2);
-                      }
                     },
                   })}
                   onKeyDown={(e) => {

--- a/src/components/travel-requests/TravelRequestForm.tsx
+++ b/src/components/travel-requests/TravelRequestForm.tsx
@@ -52,15 +52,23 @@ const formSchema = z.object({
   priority: z.enum(["alta", "media", "baja"]),
   requirements: z.string().optional(),
   advance_money: z
-    .number()
-    .int()
-    .positive({ message: "El dinero adelantado debe ser positivo" }),
+    .string()
+    .trim()
+    .nonempty({ message: "Este campo es obligatorio" })
+    .refine((value) => /^\d+(\.\d{1,2})?$/.test(value), {
+      message: "Ingresa una cantidad válida con hasta dos decimales",
+    })
+    .refine((value) => Number(value) > 0, {
+      message: "El dinero adelantado debe ser mayor a 0",
+    })
+    .transform((value) => Number(value)),
   requests_destinations: z
     .array(destinationSchema)
     .min(1, "Al menos un destino"),
 });
 
-type RawFormValues = z.infer<typeof formSchema>;
+type FormValues = z.input<typeof formSchema>;
+type SubmitValues = z.output<typeof formSchema>;
 
 interface TravelRequestFormProps {
   initialData?: CreateRequest;
@@ -69,12 +77,12 @@ interface TravelRequestFormProps {
 
 interface DestinationFieldsProps {
   idx: number;
-  control: Control<RawFormValues>;
-  register: UseFormRegister<RawFormValues>;
+  control: Control<FormValues>;
+  register: UseFormRegister<FormValues>;
   destinationOptions: { id: string | number; name: string }[];
-  errors: FieldErrors<RawFormValues>["requests_destinations"];
+  errors: FieldErrors<FormValues>["requests_destinations"];
   remove: (index: number) => void;
-  setValue: UseFormSetValue<RawFormValues>;
+  setValue: UseFormSetValue<FormValues>;
   isLoadingDestinations: boolean;
 }
 
@@ -285,14 +293,14 @@ function TravelRequestForm({ initialData, requestId }: TravelRequestFormProps) {
     formState: { errors },
     reset,
     setValue,
-  } = useForm<RawFormValues>({
+  } = useForm<FormValues, unknown, SubmitValues>({
     resolver: zodResolver(formSchema),
     defaultValues: initialData || {
       id_origin_city: null,
       motive: "",
       title: "",
       priority: "media",
-      advance_money: 0,
+      advance_money: "",
       requirements: "",
       requests_destinations: [
         {
@@ -313,7 +321,7 @@ function TravelRequestForm({ initialData, requestId }: TravelRequestFormProps) {
     name: "requests_destinations",
   });
 
-  const onSubmit = async (data: RawFormValues) => {
+  const onSubmit = async (data: SubmitValues) => {
     if (!data.id_origin_city) {
       toast.error("Selecciona una ciudad de origen");
       return;
@@ -354,7 +362,7 @@ function TravelRequestForm({ initialData, requestId }: TravelRequestFormProps) {
 
     const payload = {
       id_origin_city: data.id_origin_city,
-      title: data.motive,
+      title: data.title,
       motive: data.motive,
       requirements: data.requirements || undefined,
       priority: data.priority,
@@ -492,8 +500,42 @@ function TravelRequestForm({ initialData, requestId }: TravelRequestFormProps) {
                 </label>
                 <Input
                   id="advance_money"
-                  type="number"
-                  {...register("advance_money", { valueAsNumber: true })}
+                  type="text"
+                  inputMode="decimal"
+                  placeholder="0.00"
+                  {...register("advance_money", {
+                    onChange: (e) => {
+                      let value = e.target.value;
+
+                      value = value.replace(",", ".");
+                      value = value.replace(/[^0-9.]/g, "");
+
+                      const parts = value.split(".");
+                      if (parts.length > 2) {
+                        value = `${parts[0]}.${parts.slice(1).join("")}`;
+                      }
+
+                      if (parts[1]?.length > 2) {
+                        value = `${parts[0]}.${parts[1].slice(0, 2)}`;
+                      }
+
+                      e.target.value = value;
+                    },
+                    onBlur: (e) => {
+                      const value = e.target.value.trim();
+
+                      if (!value) return;
+
+                      if (/^\d+(\.\d{1,2})?$/.test(value)) {
+                        e.target.value = Number(value).toFixed(2);
+                      }
+                    },
+                  })}
+                  onKeyDown={(e) => {
+                    if (["e", "E", "+", "-"].includes(e.key)) {
+                      e.preventDefault();
+                    }
+                  }}
                 />
                 <FieldError msg={errors.advance_money?.message} />
               </div>

--- a/src/components/travel-requests/TravelRequestForm.tsx
+++ b/src/components/travel-requests/TravelRequestForm.tsx
@@ -63,8 +63,8 @@ const formSchema = z.object({
     .string()
     .trim()
     .nonempty({ message: "Este campo es obligatorio" })
-    .refine((value) => /^\d+(\.\d{1,2})?$/.test(value), {
-      message: "Ingresa una cantidad válida con hasta dos decimales",
+    .refine((value) => /^\d+$/.test(value), {
+      message: "Ingresa un número entero (sin decimales)",
     })
     .refine((value) => Number(value) > 0, {
       message: "El dinero adelantado debe ser mayor a 0",
@@ -525,35 +525,17 @@ function TravelRequestForm({ initialData, requestId }: TravelRequestFormProps) {
                 </label>
                 <Input
                   id="advance_money"
-                  type="text"
-                  inputMode="decimal"
-                  placeholder="0.00"
+                  type="number"
+                  step="1"
+                  placeholder="0"
                   {...register("advance_money", {
                     onChange: (e) => {
                       let value = e.target.value;
 
-                      value = value.replace(",", ".");
-                      value = value.replace(/[^0-9.]/g, "");
-
-                      const parts = value.split(".");
-                      if (parts.length > 2) {
-                        value = `${parts[0]}.${parts.slice(1).join("")}`;
-                      }
-
-                      if (parts[1]?.length > 2) {
-                        value = `${parts[0]}.${parts[1].slice(0, 2)}`;
-                      }
+                      // solo números enteros
+                      value = value.replace(/[^0-9]/g, "");
 
                       e.target.value = value;
-                    },
-                    onBlur: (e) => {
-                      const value = e.target.value.trim();
-
-                      if (!value) return;
-
-                      if (/^\d+(\.\d{1,2})?$/.test(value)) {
-                        e.target.value = Number(value).toFixed(2);
-                      }
                     },
                   })}
                   onKeyDown={(e) => {

--- a/src/components/travel-requests/TravelRequestForm.tsx
+++ b/src/components/travel-requests/TravelRequestForm.tsx
@@ -320,7 +320,7 @@ function TravelRequestForm({ initialData, requestId }: TravelRequestFormProps) {
       motive: "",
       title: "",
       priority: "media",
-      advance_money: "",
+      advance_money: 0,
       requirements: "",
       requests_destinations: [
         {

--- a/src/components/travel-requests/TravelRequestForm.tsx
+++ b/src/components/travel-requests/TravelRequestForm.tsx
@@ -60,15 +60,23 @@ const formSchema = z.object({
   priority: z.enum(["alta", "media", "baja"]),
   requirements: z.string().optional(),
   advance_money: z
-    .number()
-    .int()
-    .positive({ message: "El dinero adelantado debe ser positivo" }),
+    .string()
+    .trim()
+    .nonempty({ message: "Este campo es obligatorio" })
+    .refine((value) => /^\d+(\.\d{1,2})?$/.test(value), {
+      message: "Ingresa una cantidad válida con hasta dos decimales",
+    })
+    .refine((value) => Number(value) > 0, {
+      message: "El dinero adelantado debe ser mayor a 0",
+    })
+    .transform((value) => Number(value)),
   requests_destinations: z
     .array(destinationSchema)
     .min(1, "Al menos un destino"),
 });
 
-type RawFormValues = z.infer<typeof formSchema>;
+type FormValues = z.input<typeof formSchema>;
+type SubmitValues = z.output<typeof formSchema>;
 
 interface TravelRequestFormProps {
   initialData?: CreateRequest;
@@ -77,12 +85,12 @@ interface TravelRequestFormProps {
 
 interface DestinationFieldsProps {
   idx: number;
-  control: Control<RawFormValues>;
-  register: UseFormRegister<RawFormValues>;
+  control: Control<FormValues>;
+  register: UseFormRegister<FormValues>;
   destinationOptions: { id: string | number; name: string }[];
-  errors: FieldErrors<RawFormValues>["requests_destinations"];
+  errors: FieldErrors<FormValues>["requests_destinations"];
   remove: (index: number) => void;
-  setValue: UseFormSetValue<RawFormValues>;
+  setValue: UseFormSetValue<FormValues>;
   isLoadingDestinations: boolean;
 }
 
@@ -305,14 +313,14 @@ function TravelRequestForm({ initialData, requestId }: TravelRequestFormProps) {
     formState: { errors },
     reset,
     setValue,
-  } = useForm<RawFormValues>({
+  } = useForm<FormValues, unknown, SubmitValues>({
     resolver: zodResolver(formSchema),
     defaultValues: initialData || {
       id_origin_city: null,
       motive: "",
       title: "",
       priority: "media",
-      advance_money: 0,
+      advance_money: "",
       requirements: "",
       requests_destinations: [
         {
@@ -335,10 +343,10 @@ function TravelRequestForm({ initialData, requestId }: TravelRequestFormProps) {
 
   /**
    * onSubmit, Validates destination stay rules, builds payload data, and creates or updates a request.
-   * Inputs:data: RawFormValues - Validated form values provided by react-hook-form.
+   * Inputs:data: SubmitValues - Validated form values provided by react-hook-form.
    * Returns: Promise<void> - Executes mutation requests and navigation side effects.
    */
-  const onSubmit = async (data: RawFormValues) => {
+  const onSubmit = async (data: SubmitValues) => {
     if (!data.id_origin_city) {
       toast.error("Selecciona una ciudad de origen");
       return;
@@ -379,7 +387,7 @@ function TravelRequestForm({ initialData, requestId }: TravelRequestFormProps) {
 
     const payload = {
       id_origin_city: data.id_origin_city,
-      title: data.motive,
+      title: data.title,
       motive: data.motive,
       requirements: data.requirements || undefined,
       priority: data.priority,
@@ -517,8 +525,42 @@ function TravelRequestForm({ initialData, requestId }: TravelRequestFormProps) {
                 </label>
                 <Input
                   id="advance_money"
-                  type="number"
-                  {...register("advance_money", { valueAsNumber: true })}
+                  type="text"
+                  inputMode="decimal"
+                  placeholder="0.00"
+                  {...register("advance_money", {
+                    onChange: (e) => {
+                      let value = e.target.value;
+
+                      value = value.replace(",", ".");
+                      value = value.replace(/[^0-9.]/g, "");
+
+                      const parts = value.split(".");
+                      if (parts.length > 2) {
+                        value = `${parts[0]}.${parts.slice(1).join("")}`;
+                      }
+
+                      if (parts[1]?.length > 2) {
+                        value = `${parts[0]}.${parts[1].slice(0, 2)}`;
+                      }
+
+                      e.target.value = value;
+                    },
+                    onBlur: (e) => {
+                      const value = e.target.value.trim();
+
+                      if (!value) return;
+
+                      if (/^\d+(\.\d{1,2})?$/.test(value)) {
+                        e.target.value = Number(value).toFixed(2);
+                      }
+                    },
+                  })}
+                  onKeyDown={(e) => {
+                    if (["e", "E", "+", "-"].includes(e.key)) {
+                      e.preventDefault();
+                    }
+                  }}
                 />
                 <FieldError msg={errors.advance_money?.message} />
               </div>

--- a/src/pages/Reservations/Reservations.tsx
+++ b/src/pages/Reservations/Reservations.tsx
@@ -3,7 +3,7 @@
  * Description: Reservations page component, which displays a list of destinations and allows users to assign reservations to each destination.
  * Authors: Original Moncarca team
  * Last Modification made: 
- * 06/04/2026 Rebeca Davila Added a pdf preview for the plane and hotel documents after uploading the files
+ * 14/04/2026 - (JinSik Yoon) Added file upload functionality and preview for reservations.
  * to the form
  */
 import { useEffect, useState } from "react";

--- a/src/pages/Reservations/Reservations.tsx
+++ b/src/pages/Reservations/Reservations.tsx
@@ -115,8 +115,6 @@ export const Reservations = () => {
         ...prev,
         [errorKey]: "Este formato no es válido. Solo se permiten PDF y XML.",
       }));
-
-      // limpiar input
       e.target.value = "";
 
       return;

--- a/src/pages/Reservations/Reservations.tsx
+++ b/src/pages/Reservations/Reservations.tsx
@@ -33,6 +33,7 @@ export const Reservations = () => {
   const [isFormValid, _setIsFormValid] = useState(true);
   const { handleVisitPage, tutorial } = useApp();
   const [activePreview, setActivePreview] = useState<string | null>(null);
+  const [fileErrors, setFileErrors] = useState<Record<string, string>>({});
 
   useEffect(() => {
     const fetchRequest = async () => {
@@ -90,19 +91,53 @@ export const Reservations = () => {
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>, id: string) => {
     const { name, files } = e.target;
     const file = files ? files[0] : null;
-    const fileName = file ? file.name : "";
 
-    const previewUrl = file ? URL.createObjectURL(file) : null;
-    
+    if (!file) return;
+
+    const allowedMimeTypes = [
+      "application/pdf",
+      "application/xml",
+      "text/xml",
+    ];
+
+    const allowedExtensions = [".pdf", ".xml"];
+    const fileName = file.name;
+    const fileExtension = fileName.substring(fileName.lastIndexOf(".")).toLowerCase();
+
+    const isValidMimeType = allowedMimeTypes.includes(file.type);
+    const isValidExtension = allowedExtensions.includes(fileExtension);
+
+    const errorKey = `${id}_${name}`;
+
+    // invalid file → set error message
+    if (!isValidMimeType || !isValidExtension) {
+      setFileErrors((prev) => ({
+        ...prev,
+        [errorKey]: "Este formato no es válido. Solo se permiten PDF y XML.",
+      }));
+
+      // limpiar input
+      e.target.value = "";
+
+      return;
+    }
+
+    // valid file → clear error message, set preview URL, and update form data
+    setFileErrors((prev) => ({
+      ...prev,
+      [errorKey]: "",
+    }));
+
+    const previewUrl = URL.createObjectURL(file);
+
     const updatedFormData = {
       ...formData,
       [id]: {
         ...formData[id],
         [name]: file,
-        // Guardar también el nombre del archivo para mostrarlo
         [`${name}_name`]: fileName,
         [`${name}_preview`]: previewUrl,
-      }
+      },
     };
     setFormData(updatedFormData);
   };
@@ -333,12 +368,17 @@ export const Reservations = () => {
                           
                           <Input
                             type="file"
-                            accept=".pdf"
+                            accept="*"
                             onChange={(e) => handleFileChange(e, destination.id)}
                             name="hotel_file"
                             id={`hotel_file_${destination.id}`}
                             selectedFileName={formData[destination.id]?.hotel_file_name}
                           />
+                          {fileErrors[`${destination.id}_hotel_file`] && (
+                            <p className="text-red-500 text-sm mt-1">
+                              {fileErrors[`${destination.id}_hotel_file`]}
+                            </p>
+                          )}
                           {formData[destination.id]?.hotel_file_preview && (
                             <button
                               type="button"
@@ -413,12 +453,17 @@ export const Reservations = () => {
                           </label>
                           <Input
                             type="file"
-                            accept=".pdf"
+                            accept="*"
                             onChange={(e) => handleFileChange(e, destination.id)}
                             name="plane_file"
                             id={`plane_file_${destination.id}`}
                             selectedFileName={formData[destination.id]?.plane_file_name}
                           />
+                          {fileErrors[`${destination.id}_plane_file`] && (
+                            <p className="text-red-500 text-sm mt-1">
+                              {fileErrors[`${destination.id}_plane_file`]}
+                            </p>
+                          )}
                           {formData[destination.id]?.plane_file_preview && (
                             <button
                               type="button"


### PR DESCRIPTION
Improve validation and input handling for advance_money field
- allow decimal values up to two digits
- prevent negative values and zero
- remove valueAsNumber to avoid NaN issues
- replace integer validation with monetary validation
- standardize error messages in Spanish
- restrict invalid input formats
- format values like 50.5 to 50.50"

Implement frontend file type validation for uploads
- Added validation for PDF and XML formats
- Display error message below input for invalid files
- Prevent invalid files from being stored
- Removed toast-based warnings for better UX"

Closes #33 