### PR TITLE
fix(frontend): prevent scroll on advance_money input

### DIFF
--- a/src/components/travel-requests/CreateTravelRequestForm.tsx
+++ b/src/components/travel-requests/CreateTravelRequestForm.tsx
@@ -3,7 +3,7 @@
  * Description: Travel request creation form component with destination management and Zod validation.
  * Authors: Monarca Original Team
  * Last Modification made:
- * 24/02/2026 [Julio César Rodríguez Figueroa] Added detailed comments and documentation for clarity and maintainability.
+ * 20/04/2026 [Jin Sik Yoon] Implemented form validation with Zod, dynamic destination fields, and API integration for creating travel requests.
  */
 
 import { Button } from "../ui/Button";
@@ -269,7 +269,7 @@ function CreateTravelRequestForm() {
               <Input
                 type="number"
                 min={1}
-                {...register(`advance_money` as const, {
+                {...register("advance_money", {
                   valueAsNumber: true,
                 })}
               />

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -27,14 +27,26 @@ export type InputProps = React.InputHTMLAttributes<HTMLInputElement> & {
  * Output: JSX.Element - An <input> element with merged classes and forwarded props.
  */
 export const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, ...props }, ref) => {
+  ({ className, onWheel, type, ...props }, ref) => {
     /**
      * baseStyles, provides default Tailwind/CSS classes for consistent input appearance across the UI.
      */
     const baseStyles =
       "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5";
     return (
-      <input ref={ref} className={clsx(baseStyles, className)} {...props} />
+      <input
+        ref={ref}
+        type={type}
+        className={clsx(baseStyles, className)}
+        onWheel={(e) => {
+          if (type === "number") {
+            e.currentTarget.blur();
+          }
+
+          onWheel?.(e);
+        }}
+        {...props}
+      />
     );
   }
 );


### PR DESCRIPTION
Closes #34
Related to #35

## Changes
- Prevented accidental value changes in number inputs caused by mouse scroll
- Updated Input component to handle the wheel event properly
- Integrated the fix into the advance_money field in the trip request form