### PR TITLE
feat(frontend): added info recovery for requests and reservatonis

### DIFF
--- a/src/components/travel-requests/CreateTravelRequestForm.tsx
+++ b/src/components/travel-requests/CreateTravelRequestForm.tsx
@@ -25,6 +25,7 @@ import FieldError from "../ui/FieldError";
 
 import { useCreateTravelRequest } from "../../hooks/requests/useCreateRequest";
 import { useDestinations } from "../../hooks/destinations/useDestinations";
+import { usePersistedForm } from "../../hooks/app/usePersistedForm";
 
 type Option = { id: number | string; name: string };
 
@@ -107,6 +108,12 @@ function CreateTravelRequestForm() {
 
   const { createTravelRequestMutation, isPending } = useCreateTravelRequest();
 
+  const { clearPersistedForm } = usePersistedForm<RawFormValues>({
+    storageKey: "createTravelRequestForm:legacy",
+    control,
+    reset,
+  });
+
   const { fields, append, remove } = useFieldArray({
     control,
     name: "destinations",
@@ -161,6 +168,7 @@ function CreateTravelRequestForm() {
         closeOnClick: true,
         pauseOnHover: true,
       });
+      clearPersistedForm();
       reset();
       navigate("/dashboard");
     } catch (error) {

--- a/src/components/travel-requests/TravelRequestForm.tsx
+++ b/src/components/travel-requests/TravelRequestForm.tsx
@@ -328,13 +328,17 @@ function TravelRequestForm({ initialData, requestId }: TravelRequestFormProps) {
       return undefined;
     }
 
+    const parsedAdvanceMoney = Number(initialData.advance_money);
+
     return {
       ...initialData,
       id_origin_city: initialData.id_origin_city ?? null,
       advance_money:
         initialData.advance_money !== undefined &&
         initialData.advance_money !== null
-          ? initialData.advance_money.toFixed(2)
+          ? Number.isFinite(parsedAdvanceMoney)
+            ? parsedAdvanceMoney.toFixed(2)
+            : "0.00"
           : "0.00",
       requests_destinations: initialData.requests_destinations.map((destination) => ({
         ...destination,
@@ -383,6 +387,7 @@ function TravelRequestForm({ initialData, requestId }: TravelRequestFormProps) {
     storageKey: persistStorageKey,
     control,
     reset,
+    enabled: !isEditing,
   });
 
   const { fields, append, remove } = useFieldArray({

--- a/src/components/travel-requests/TravelRequestForm.tsx
+++ b/src/components/travel-requests/TravelRequestForm.tsx
@@ -7,6 +7,7 @@
  * 20/04/2026 [Sebastián Borjas] Fixed currency display on edit.
  * 20/04/2026 [Jin Sik Yoon] Improved error handling for better UX.
  * 20/04/2026 [Diego de la Vega] Enabled searchable origin/destination selectors with incremental filtering while typing.
+ * 23/04/2026 [Santiago Coronado Hernández] Use PersistedForm hook to save form state in localStorage for better UX on accidental refreshes or navigation.
  */
 
 import { Button } from "../ui/Button";
@@ -36,6 +37,7 @@ import { CreateRequest } from "../../types/requests";
 import GoBack from "../GoBack";
 import { useEffect, useMemo } from "react";
 import { currencyOptions } from "../../utils/currencies";
+import { usePersistedForm } from "../../hooks/app/usePersistedForm";
 
 type Option = { id: number | string; name: string };
 
@@ -372,6 +374,17 @@ function TravelRequestForm({ initialData, requestId }: TravelRequestFormProps) {
     },
   });
 
+  const persistStorageKey =
+    isEditing && requestId
+      ? `travelRequestForm:edit:${requestId}`
+      : "travelRequestForm:create";
+
+  const { clearPersistedForm } = usePersistedForm<FormValues, SubmitValues>({
+    storageKey: persistStorageKey,
+    control,
+    reset,
+  });
+
   const { fields, append, remove } = useFieldArray({
     control,
     name: "requests_destinations",
@@ -441,6 +454,7 @@ function TravelRequestForm({ initialData, requestId }: TravelRequestFormProps) {
         toast.success("¡Solicitud de viaje creada exitosamente!");
       }
 
+      clearPersistedForm();
       reset();
       navigate("/dashboard");
     } catch (error) {

--- a/src/components/travel-requests/TravelRequestForm.tsx
+++ b/src/components/travel-requests/TravelRequestForm.tsx
@@ -65,7 +65,7 @@ const formSchema = z.object({
   motive: z.string().nonempty({ message: "Escribe el motivo del viaje" }),
   title: z.string().nonempty({ message: "Escribe el título del viaje" }),
   priority: z.enum(["alta", "media", "baja"]),
-  requirements: z.string().optional(),
+  requirements: z.string().nullable().optional(),
   advance_money: z
     .string()
     .trim()

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -5,6 +5,7 @@
  * Authors: Original Moncarca team
  * Last Modification made:
  * 20/04/2026 [Jin Sik Yoon] Improved error handling for better UX.
+ * 23/04/2026 [Santiago Coronado Hernández] Added onWheel and onFocus handler for number inputs to allow incrementing/decrementing values with mouse wheel, and ensured proper cleanup of event listeners on blur to prevent memory leaks.
  */
 import React from "react";
 import clsx from "clsx";
@@ -27,7 +28,7 @@ export type InputProps = React.InputHTMLAttributes<HTMLInputElement> & {
  * Output: JSX.Element - An <input> element with merged classes and forwarded props.
  */
 export const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, onWheel, type, onFocus, onBlur, ...props }, ref) => {
+  ({ className, onWheel, onFocus, onBlur, type, ...props }, ref) => {
     /**
      * baseStyles, provides default Tailwind/CSS classes for consistent input appearance across the UI.
      */

--- a/src/hooks/app/usePersistedForm.ts
+++ b/src/hooks/app/usePersistedForm.ts
@@ -1,0 +1,94 @@
+/**
+ * FileName: usePersistedForm.ts
+ * Description: Custom React hook to persist form state in localStorage using react-hook-form.
+ * Authors: DebugStudio Team
+ * Last Modification made:
+ * 23/04/2026 [Santiago-Coronado] Created usePersistedForm hook to automatically save and restore form state in localStorage, improving UX by preventing data loss on accidental refreshes or navigation.
+ */
+import { useEffect, useRef } from "react";
+import { Control, FieldValues, UseFormReset, useWatch } from "react-hook-form";
+
+interface UsePersistedFormParams<
+  T extends FieldValues,
+  TTransformedValues extends FieldValues = T,
+> {
+  storageKey: string;
+  control: Control<T, unknown, TTransformedValues>;
+  reset: UseFormReset<T>;
+  enabled?: boolean;
+}
+
+/**
+ * FunctionName: usePersistedForm, a custom React hook that integrates with react-hook-form to persist form state in localStorage.
+ * Input: 
+ * - storageKey (string): The key under which the form state will be stored in localStorage.
+ * - control (Control): The react-hook-form control instance.
+ * - reset (UseFormReset): The reset function from react-hook-form.
+ * - enabled (boolean): Whether the persistence is enabled.
+ * Output: An object containing the clearPersistedForm function.
+ */
+export function usePersistedForm<
+  T extends FieldValues,
+  TTransformedValues extends FieldValues = T,
+>({
+  storageKey,
+  control,
+  reset,
+  enabled = true,
+}: UsePersistedFormParams<T, TTransformedValues>) {
+  const values = useWatch({ control });
+  const isHydratedRef = useRef(false);
+  const hasSkippedInitialPersistRef = useRef(false);
+  const isPersistenceEnabledRef = useRef(true);
+
+  useEffect(() => {
+    if (!enabled || typeof window === "undefined") {
+      isHydratedRef.current = true;
+      return;
+    }
+
+    try {
+      const storedValue = window.localStorage.getItem(storageKey);
+      if (storedValue) {
+        const parsed = JSON.parse(storedValue) as T;
+        reset(parsed);
+      }
+    } catch {
+      window.localStorage.removeItem(storageKey);
+    } finally {
+      isHydratedRef.current = true;
+    }
+  }, [enabled, reset, storageKey]);
+
+  useEffect(() => {
+    if (!enabled || typeof window === "undefined" || !isHydratedRef.current) {
+      return;
+    }
+
+    if (!isPersistenceEnabledRef.current) {
+      return;
+    }
+
+    if (!hasSkippedInitialPersistRef.current) {
+      hasSkippedInitialPersistRef.current = true;
+      return;
+    }
+
+    try {
+      window.localStorage.setItem(storageKey, JSON.stringify(values));
+    } catch {
+      // Ignore quota and serialization errors to avoid blocking form usage.
+    }
+  }, [enabled, storageKey, values]);
+
+  const clearPersistedForm = () => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    isPersistenceEnabledRef.current = false;
+    window.localStorage.removeItem(storageKey);
+  };
+
+  return { clearPersistedForm };
+}

--- a/src/pages/EditTravelRequest.tsx
+++ b/src/pages/EditTravelRequest.tsx
@@ -18,6 +18,19 @@ function EditTravelRequest() {
   const { id } = useParams<{ id: string }>();
   const { data: travelRequest, isLoading } = useGetRequest(id!);
 
+  const normalizeAmount = (value: unknown): number | undefined => {
+    if (value === null || value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value === "string" && value.trim() === "") {
+      return undefined;
+    }
+
+    const parsedValue = Number(value);
+    return Number.isFinite(parsedValue) ? parsedValue : undefined;
+  };
+
   console.log(travelRequest);
 
   if (isLoading) {
@@ -34,7 +47,9 @@ function EditTravelRequest() {
         requestId={id}
         initialData={{
           ...travelRequest,
-          advance_money: travelRequest.unconverted_advance_money ?? travelRequest.advance_money
+          advance_money:
+            normalizeAmount(travelRequest.unconverted_advance_money) ??
+            normalizeAmount(travelRequest.advance_money),
         }}
       />
     </div>

--- a/src/pages/RequestInfo.tsx
+++ b/src/pages/RequestInfo.tsx
@@ -115,6 +115,19 @@ const RequestInfo: React.FC = () => {
 
   const { handleVisitPage, tutorial } = useApp();
 
+  const normalizeAmount = (value: unknown): number | undefined => {
+    if (value === null || value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value === 'string' && value.trim() === '') {
+      return undefined;
+    }
+
+    const parsedValue = Number(value);
+    return Number.isFinite(parsedValue) ? parsedValue : undefined;
+  };
+
   const getStoredDraft = () => {
     if (typeof window === 'undefined') {
       return null;
@@ -150,17 +163,33 @@ const RequestInfo: React.FC = () => {
       try {
         const response = await getRequest(`/requests/${requestId}`);
         const draft = getStoredDraft();
+        const normalizedAdvanceMoney = normalizeAmount(response.advance_money);
+        const normalizedUnconvertedAdvanceMoney = normalizeAmount(
+          response.unconverted_advance_money,
+        );
+        const effectiveAdvanceMoney =
+          normalizedUnconvertedAdvanceMoney ?? normalizedAdvanceMoney ?? 0;
         const reservations = (response.requests_destinations || [])
           .map((dest: any) => dest.reservations)
           .flat();
         console.log(response);
         setData({
           ...response,
+          effective_advance_money: effectiveAdvanceMoney,
           reservations: reservations,
           formatted_status: renderStatus(response.status),
           createdAt: formatDate(response.createdAt),
-          advance_money_str: formatMoney(response.advance_money, "MXN"),
-          unconverted_advance_money_str: response.currency && response.currency !== "MXN" ? formatMoney(response.unconverted_advance_money, response.currency) : undefined,
+          advance_money_str: formatMoney(
+            normalizedAdvanceMoney ?? effectiveAdvanceMoney,
+            "MXN",
+          ),
+          unconverted_advance_money_str:
+            response.currency && response.currency !== "MXN"
+              ? formatMoney(
+                  normalizedUnconvertedAdvanceMoney ?? effectiveAdvanceMoney,
+                  response.currency,
+                )
+              : undefined,
           exchange_rate_str: response.currency && response.currency !== "MXN" ? `$${response.exchange_rate} MXN` : undefined,
           admin: response.admin.name + ' ' + response.admin.last_name,
           id_origin_city:
@@ -447,6 +476,16 @@ const RequestInfo: React.FC = () => {
       return;
     }
   }
+
+  const previewAdvanceMoney = normalizeAmount(data?.effective_advance_money) ?? 0;
+  const approvedVoucherTotal =
+    data?.vouchers?.reduce((acc: number, file: { status: string; amount: number }) => {
+      if (file.status === "Voucher Approved") {
+        return acc + Number(file.amount);
+      }
+      return acc;
+    }, 0) ?? 0;
+  const previewBalance = previewAdvanceMoney - approvedVoucherTotal;
 
   return ( // Returns the main JSX content of the RequestInfo page, including request details, destinations, reservations, vouchers, and action buttons based on user permissions and request status.
     <Tutorial page="requestInfo" run={tutorial}>
@@ -755,12 +794,7 @@ const RequestInfo: React.FC = () => {
                         id="total_vouchers"
                         type="text"
                         readOnly
-                        value={formatMoney(data?.vouchers?.reduce((acc: number, file: { status: string; amount: number }) => {
-                          if (file.status === "Voucher Approved") {
-                            return acc + +file.amount;
-                          }
-                          return acc;
-                        }, 0) ?? 0)}
+                        value={formatMoney(approvedVoucherTotal)}
                         className="w-full bg-gray-100 text-gray-800 rounded-lg px-3 py-2 border border-gray-200"
                       />
                     </div>
@@ -775,7 +809,7 @@ const RequestInfo: React.FC = () => {
                         id="advance_money"
                         type="text"
                         readOnly
-                        value={formatMoney(Number(data?.advance_money) || 0, "MXN")}
+                        value={formatMoney(previewAdvanceMoney, "MXN")}
                         className="w-full bg-gray-100 text-gray-800 rounded-lg px-3 py-2 border border-gray-200"
                       />
                     </div>
@@ -784,35 +818,15 @@ const RequestInfo: React.FC = () => {
                         htmlFor={"total"}
                         className="block text-xs font-semibold text-gray-500 mb-1"
                       >
-                        Saldo {(typeof data?.advance_money === "number" ? data.advance_money : Number(data?.advance_money) || 0) -
-                          (data?.vouchers?.reduce((acc: number, file: { status: string; amount: number }) => {
-                            if (file.status === "Voucher Approved") {
-                              return acc + Number(file.amount);
-                            }
-                            return acc;
-                          }, 0) ?? 0) < 0 ? "a favor" : "en contra"}
+                        Saldo {previewBalance < 0 ? "a favor" : "en contra"}
                       </label>
                       <input
                         id="balance"
                         type="text"
                         readOnly
-                        value={formatMoney(
-                          Math.abs((typeof data?.advance_money === "number" ? data.advance_money : Number(data?.advance_money) || 0) -
-                            (data?.vouchers?.reduce((acc: number, file: { status: string; amount: number }) => {
-                              if (file.status === "Voucher Approved") {
-                                return acc + Number(file.amount);
-                              }
-                              return acc;
-                            }, 0) ?? 0)), "MXN"
-                        )}
+                        value={formatMoney(Math.abs(previewBalance), "MXN")}
                         className={`w-full bg-gray-100 text-gray-800 rounded-lg px-3 py-2 border border-gray-200
-                      ${(typeof data?.advance_money === "number" ? data.advance_money : Number(data?.advance_money) || 0) -
-                            (data?.vouchers?.reduce((acc: number, file: { status: string; amount: number }) => {
-                              if (file.status === "Voucher Approved") {
-                                return acc + Number(file.amount);
-                              }
-                              return acc;
-                            }, 0) ?? 0) > 0 ? "text-red-500" : "text-green-600"
+                      ${previewBalance > 0 ? "text-red-500" : "text-green-600"
                           }`}
                       />
                     </div>

--- a/src/pages/RequestInfo.tsx
+++ b/src/pages/RequestInfo.tsx
@@ -88,11 +88,22 @@ const renderProviderSupportStatus = (status?: string) => {
 const RequestInfo: React.FC = () => {
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
+  const requestId =
+    id ||
+    (typeof window !== 'undefined'
+      ? window.location.pathname.split('/').filter(Boolean).pop()
+      : undefined);
   const { authState } = useAuth();
   const [data, setData] = useState<any>({});
   const [comment, setComment] = useState('');
   const [agencies, setAgencies] = useState<any[]>([]);
   const [selectedAgency, setSelectedAgency] = useState('');
+  const isDraftHydratedRef = React.useRef(false);
+  const hasSkippedInitialPersistRef = React.useRef(false);
+  const isPersistenceEnabledRef = React.useRef(true);
+  const requestInfoDraftKey = requestId
+    ? `requestInfoDraft:${requestId}`
+    : 'requestInfoDraft:unknown';
 
   const [currentIndex, setCurrentIndex] = useState(0);
   const prevRef = React.useRef(null);
@@ -104,6 +115,31 @@ const RequestInfo: React.FC = () => {
 
   const { handleVisitPage, tutorial } = useApp();
 
+  const getStoredDraft = () => {
+    if (typeof window === 'undefined') {
+      return null;
+    }
+
+    try {
+      const rawDraft = window.localStorage.getItem(requestInfoDraftKey);
+      return rawDraft
+        ? (JSON.parse(rawDraft) as { comment?: string; selectedAgency?: string })
+        : null;
+    } catch {
+      window.localStorage.removeItem(requestInfoDraftKey);
+      return null;
+    }
+  };
+
+  const clearRequestInfoDraft = () => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    isPersistenceEnabledRef.current = false;
+    window.localStorage.removeItem(requestInfoDraftKey);
+  };
+
   useEffect(() => {
     /**
      * fetchData, loads request data from API and normalizes fields for UI display.
@@ -112,7 +148,8 @@ const RequestInfo: React.FC = () => {
      */
     const fetchData = async () => {
       try {
-        const response = await getRequest(`/requests/${id}`);
+        const response = await getRequest(`/requests/${requestId}`);
+        const draft = getStoredDraft();
         const reservations = (response.requests_destinations || [])
           .map((dest: any) => dest.reservations)
           .flat();
@@ -139,14 +176,58 @@ const RequestInfo: React.FC = () => {
             )
             .join(', '),
         });
-        setSelectedAgency(response.id_travel_agency || '');
+        setSelectedAgency(draft?.selectedAgency || response.id_travel_agency || '');
+        setComment(draft?.comment || '');
       } catch (error) {
         console.error('Error fetching request data:', error);
       }
     };
 
     fetchData();
-  }, []);
+  }, [requestId]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !requestId) {
+      isDraftHydratedRef.current = true;
+      return;
+    }
+
+    const draft = getStoredDraft();
+    if (draft) {
+      setComment(draft.comment || '');
+      setSelectedAgency(draft.selectedAgency || '');
+    }
+
+    isDraftHydratedRef.current = true;
+  }, [requestId]);
+
+  useEffect(() => {
+    if (
+      typeof window === 'undefined' ||
+      !requestId ||
+      !isDraftHydratedRef.current ||
+      !isPersistenceEnabledRef.current
+    ) {
+      return;
+    }
+
+    if (!hasSkippedInitialPersistRef.current) {
+      hasSkippedInitialPersistRef.current = true;
+      return;
+    }
+
+    try {
+      window.localStorage.setItem(
+        requestInfoDraftKey,
+        JSON.stringify({
+          comment,
+          selectedAgency,
+        })
+      );
+    } catch {
+      // Ignore localStorage write errors to keep the screen usable.
+    }
+  }, [comment, selectedAgency, requestId, requestInfoDraftKey]);
 
   useEffect(() => {
     // Get the visited pages from localStorage
@@ -213,6 +294,7 @@ const RequestInfo: React.FC = () => {
       await patchRequest(`/requests/approve/${id}`, {
         id_travel_agency: selectedAgency,
       });
+      clearRequestInfoDraft();
       toast.success(`Solicitud aprobada con ${selectedAgency}`, {
         position: 'top-right',
         autoClose: 3000,
@@ -248,6 +330,7 @@ const RequestInfo: React.FC = () => {
         id_request: id,
         comment: comment,
       });
+      clearRequestInfoDraft();
       toast.info('Se han solicitado cambios', {
         position: 'top-right',
         autoClose: 3000,
@@ -273,6 +356,7 @@ const RequestInfo: React.FC = () => {
   const deny = async () => {
     try {
       await patchRequest(`/requests/deny/${id}`, {});
+      clearRequestInfoDraft();
       toast.error('Solicitud denegada', {
         position: 'top-right',
         autoClose: 3000,
@@ -298,6 +382,7 @@ const RequestInfo: React.FC = () => {
   const cancel = async () => {
     try {
       await patchRequest(`/requests/cancel/${id}`, {});
+      clearRequestInfoDraft();
       toast.error('Solicitud cancelada', {
         position: 'top-right',
         autoClose: 3000,
@@ -323,6 +408,7 @@ const RequestInfo: React.FC = () => {
   const register = async () => {
     try {
       await patchRequest(`/requests/SOI-approve/${id}`, {});
+      clearRequestInfoDraft();
       toast.success('Solicitud marcada como registrada', {
         position: 'top-right',
         autoClose: 3000,
@@ -346,6 +432,7 @@ const RequestInfo: React.FC = () => {
   const complete = async () => {
     try {
       await patchRequest(`/requests/complete-request/${id}`, {});
+      clearRequestInfoDraft();
       toast.success('Solicitud marcada como completada', {
         position: 'top-right',
         autoClose: 3000,

--- a/src/pages/Reservations/Reservations.tsx
+++ b/src/pages/Reservations/Reservations.tsx
@@ -7,8 +7,9 @@
  * to the form
  * 20/04/2026 [Diego de la Vega] Added fallback mapping for origin/destination
  *                             values and defensive handling of empty destination arrays.
+ * 23/04/2026 [Santiago-Coronado] Implemented form state persistence in localStorage to prevent data loss on accidental refreshes.
  */
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import Input from "../../components/Refunds/InputField";
 import TextArea from "../../components/Refunds/TextArea";
@@ -30,18 +31,94 @@ import { useApp } from "../../hooks/app/appContext";
 export const Reservations = () => {
   const navigate = useNavigate();
   const { id } = useParams();
+  const requestId =
+    id ||
+    (typeof window !== "undefined"
+      ? window.location.pathname.split("/").filter(Boolean).pop()
+      : undefined);
   const [formData, setFormData] = useState<Record<string, any>>({});
   const [request, setRequest] = useState<any>({});
   const [isFormValid, _setIsFormValid] = useState(true);
   const { handleVisitPage, tutorial } = useApp();
   const [activePreview, setActivePreview] = useState<string | null>(null);
   const [fileErrors, setFileErrors] = useState<Record<string, string>>({});
+  const isDraftHydratedRef = useRef(false);
+  const hasSkippedInitialPersistRef = useRef(false);
+  const isPersistenceEnabledRef = useRef(true);
+  const reservationDraftStorageKey = requestId
+    ? `reservationsFormDraft:${requestId}`
+    : "reservationsFormDraft:unknown";
+
+  const getPersistableFormData = (data: Record<string, any>) => {
+    return Object.fromEntries(
+      Object.entries(data).map(([destinationId, values]) => {
+        const cleanedValues = Object.fromEntries(
+          Object.entries(values || {}).filter(([fieldName]) => {
+            return (
+              !fieldName.endsWith("_file") &&
+              !fieldName.endsWith("_file_name") &&
+              !fieldName.endsWith("_preview")
+            );
+          })
+        );
+
+        return [destinationId, cleanedValues];
+      })
+    );
+  };
+
+  useEffect(() => {
+    if (!requestId || typeof window === "undefined") {
+      isDraftHydratedRef.current = true;
+      return;
+    }
+
+    try {
+      const rawDraft = window.localStorage.getItem(reservationDraftStorageKey);
+      if (rawDraft) {
+        setFormData(JSON.parse(rawDraft));
+      }
+    } catch {
+      window.localStorage.removeItem(reservationDraftStorageKey);
+    } finally {
+      isDraftHydratedRef.current = true;
+    }
+  }, [id, reservationDraftStorageKey]);
+
+  useEffect(() => {
+    if (
+      !requestId ||
+      typeof window === "undefined" ||
+      !isDraftHydratedRef.current
+    ) {
+      return;
+    }
+
+    if (!isPersistenceEnabledRef.current) {
+      return;
+    }
+
+    if (!hasSkippedInitialPersistRef.current) {
+      hasSkippedInitialPersistRef.current = true;
+      return;
+    }
+
+    try {
+      const safeFormData = getPersistableFormData(formData);
+      window.localStorage.setItem(
+        reservationDraftStorageKey,
+        JSON.stringify(safeFormData)
+      );
+    } catch {
+      // Ignore localStorage write errors to keep the form usable.
+    }
+  }, [formData, requestId, reservationDraftStorageKey]);
 
   useEffect(() => {
     const fetchRequest = async () => {
       try {
         // Simulate an API call to fetch data
-        const response = await getRequest(`/requests/${id}`);
+        const response = await getRequest(`/requests/${requestId}`);
         setRequest({
           ...response,
           requests_destinations: (response.requests_destinations || []).map((destination: any) => ({
@@ -72,7 +149,7 @@ export const Reservations = () => {
       }
     }
     fetchRequest();
-  }, []);
+  }, [requestId]);
 
   useEffect(() => {
       // Get the visited pages from localStorage
@@ -253,8 +330,10 @@ export const Reservations = () => {
       );
       if (responses) {
         toast.success("Reservaciones enviadas correctamente.");
+        isPersistenceEnabledRef.current = false;
         setFormData({});
-        await patchRequest(`/requests/finished-reservations/${id}`, {});
+        window.localStorage.removeItem(reservationDraftStorageKey);
+        await patchRequest(`/requests/finished-reservations/${requestId}`, {});
         navigate("/dashboard");
       } else {
         toast.error("Error al enviar las reservaciones.");


### PR DESCRIPTION
This pull request introduces persistent form state functionality across several key components to improve user experience by preventing data loss on accidental refreshes or navigation. 

- **Reusable Form Persistence Hook:**
  - Added a new `usePersistedForm` hook in `src/hooks/app/usePersistedForm.ts` that automatically saves and restores form state in `localStorage` for any form using `react-hook-form`. This hook provides a `clearPersistedForm` method to clear saved state when the form is successfully submitted or reset.

