### PR TITLE
feat(frontend): added notification settings page

### DIFF
--- a/src/api/companyNotificationSettings.ts
+++ b/src/api/companyNotificationSettings.ts
@@ -1,0 +1,30 @@
+/*
+ * FileName: companyNotificationSettings.ts
+ * Description: API service for managing company notification settings. Provides functions to fetch current settings and update preferences via GET and PATCH requests to the backend. 
+ *              Utilizes typed interfaces for request payloads and responses to ensure type safety in interactions with the notification settings API endpoints.
+ * Authors: Original Monarca team
+ * Last Modification made:
+ * 05/05/2026 [Santiago Coronado Hernández] Created File and implemented notification settings management for admins.
+ */
+
+import { getRequest, patchRequest } from "../utils/apiService";
+import type {
+  CompanyNotificationSettings,
+  CompanyNotificationSettingsUpdate,
+} from "../types/notification";
+
+export const getCompanyNotificationSettings = async (
+  idCompany: string,
+): Promise<CompanyNotificationSettings> => {
+  return getRequest(`/company-notification-settings/${idCompany}`);
+};
+
+export const updateCompanyNotificationSettings = async (
+  idCompany: string,
+  payload: CompanyNotificationSettingsUpdate,
+): Promise<CompanyNotificationSettings> => {
+  return patchRequest(
+    `/company-notification-settings/${idCompany}`,
+    payload as Record<string, unknown>,
+  );
+};

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -4,7 +4,7 @@
  *              and permission-based navigation links using SidebarOption items.
  * Authors: Original Moncarca team
  * Last Modification made:
- * 04/05/2026 [Julio Rodriguez] Fixed approver history label and replaced requester permission with check_budgets for SOI "Viajes por registrar" link.
+ * 05/05/2026 [Santiago Coronado Hernández] Added notifications section
  */
 
 // ***************** images *****************
@@ -81,6 +81,9 @@ function Sidebar({ user, onNavigate }: { user: AuthState, onNavigate?: () => voi
             )}
             {user.isCompanyAdmin && (
               <SidebarOption label="Reglas" pathIcon="/assets/historial_de_viajes.png" link="/admin/rules" onClick={onNavigate}/>
+            )}
+            {(user.isCompanyAdmin || user.isSystemAdmin) && (
+              <SidebarOption label="Notificaciones" pathIcon="/assets/crear_solicitud_de_viaje.png" link="/admin/notifications" onClick={onNavigate}/>
             )}
         </ul>
       </div>

--- a/src/hooks/auth/authContext.tsx
+++ b/src/hooks/auth/authContext.tsx
@@ -3,7 +3,7 @@
  * Description: Authentication and authorization context for the frontend. Provides auth state (user info + permissions), login session validation via profile endpoint, logout handling, and route protection components (basic auth + permission-based guards).
  * Authors: Original Moncarca team
  * Last Modification made:
- * 04/05/2026 [Julio Rodriguez] Removed create_company/user_list from Permission type; admin visibility now uses isSystemAdmin/isCompanyAdmin flags.
+ * 05/05/2026 [Santiago Coronado Hernández] Added company id to auth state and included it in the profile fetch logic to support company-scoped features and permissions in the frontend.
  */
 
 import React, { createContext, useContext, ReactNode, useEffect } from "react";
@@ -56,6 +56,7 @@ export interface AuthState {
   userEmail: string;
   userPermissions: Permission[];
   userRole: string;
+  companyId: string | null;
   isSystemAdmin: boolean;
   isCompanyAdmin: boolean;
 }
@@ -107,6 +108,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
     userPermissions: [],
     isSystemAdmin: false,
     isCompanyAdmin: false,
+    companyId: null,
   });
 
   useEffect(() => {
@@ -133,6 +135,8 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
                 (permission: { name: string }) => permission.name
               ),
               userEmail: response.user.email,
+              companyId:
+                response.user.id_company ?? response.user.company_id ?? response.user.company?.id ?? null,
               isSystemAdmin: response.user.is_system_admin ?? false,
               isCompanyAdmin: response.user.is_company_admin ?? false,
             });
@@ -176,6 +180,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
         userPermissions: [],
         isSystemAdmin: false,
         isCompanyAdmin: false,
+        companyId: null,
       });
     }
   };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,7 +4,7 @@
  * configures React Router routes (public and protected), and sets up TanStack Query provider for server state management.
  * Authors: Original Moncarca team
  * Last Modification made:
- * 03/05/2026 [Julio Rodriguez] Changed /admin/users to requireCompanyAdmin so both admins can access.
+ * 05/05/2026 [Santiago Coronado Hernández] Added new admin notifications page and related routes, and ensured it is protected by company admin flag.
  */
 
 import { StrictMode } from "react";
@@ -18,6 +18,7 @@ import EditTravelRequest from "./pages/EditTravelRequest.tsx";
 import AdminUsers from "./pages/Admin/AdminUsers.tsx";
 import AdminRules from "./pages/Admin/AdminRules.tsx";
 import AdminNewCompany from "./pages/Admin/AdminNewCompany.tsx";
+import AdminNotifications from "./pages/Admin/AdminNotifications.tsx";
 
 import {
   ProtectedRoute,
@@ -142,6 +143,10 @@ export const router = createBrowserRouter([
       {
         path: "/admin/rules",
         element: <FlagProtectedRoute requireCompanyAdmin><AdminRules /></FlagProtectedRoute>,
+      },
+      {
+        path: "/admin/notifications",
+        element: <FlagProtectedRoute requireCompanyAdmin><AdminNotifications /></FlagProtectedRoute>,
       },
       {
         path: "/admin/companies/new",

--- a/src/pages/Admin/AdminNotifications.tsx
+++ b/src/pages/Admin/AdminNotifications.tsx
@@ -1,0 +1,223 @@
+/*
+ * FileName: AdminNotifications.tsx
+ * Description: Admin page for managing notification settings. Allows toggling email and in-app notifications for various events at the company level. 
+ *              Fetches current settings on load and provides a form to update preferences with feedback messages on success or error.
+ * Authors: Original Monarca team
+ * Last Modification made:
+ * 05/05/2026 [Santiago Coronado Hernández] Created File and implemented notification settings management for admins.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import GoBack from "../../components/GoBack";
+import { Button } from "../../components/ui/Button";
+import Switch from "../../components/ui/Switch";
+import { useAuth } from "../../hooks/auth/authContext";
+import {
+  getCompanyNotificationSettings,
+  updateCompanyNotificationSettings,
+} from "../../api/companyNotificationSettings";
+import type {
+  CompanyNotificationSettings,
+  CompanyNotificationSettingsUpdate,
+} from "../../types/notification";
+
+type MessageState = { text: string; error: boolean } | null;
+
+const defaultSettings: CompanyNotificationSettings = {
+  id: "",
+  id_company: "",
+  email_enabled: true,
+  in_app_enabled: true,
+  email_requests_created: true,
+  email_requests_status: true,
+  email_revisions: true,
+  email_reservations: true,
+  email_admin_alerts: true,
+};
+
+const settingRows: Array<{
+  key: keyof CompanyNotificationSettingsUpdate;
+  title: string;
+  description: string;
+}> = [
+  {
+    key: "email_enabled",
+    title: "Habilitar correo",
+    description: "Permite enviar notificaciones por email para la empresa.",
+  },
+  {
+    key: "in_app_enabled",
+    title: "Habilitar notificaciones internas",
+    description: "Muestra notificaciones dentro de la aplicación.",
+  },
+  {
+    key: "email_requests_created",
+    title: "Solicitud creada",
+    description: "Notifica por email cuando se crea una solicitud.",
+  },
+  {
+    key: "email_requests_status",
+    title: "Cambio de estado de solicitud",
+    description: "Notifica por email cuando una solicitud cambia de estado.",
+  },
+  {
+    key: "email_revisions",
+    title: "Revisión creada",
+    description: "Notifica por email cuando se genera una revisión.",
+  },
+  {
+    key: "email_reservations",
+    title: "Reservación creada",
+    description: "Notifica por email cuando se crea una reservación.",
+  },
+  {
+    key: "email_admin_alerts",
+    title: "Alertas administrativas",
+    description: "Notifica por email eventos administrativos relevantes.",
+  },
+];
+
+const sectionClass = "bg-gray-200 rounded-md";
+const labelClass = "block text-sm font-medium text-gray-900";
+
+export default function AdminNotifications() {
+  const { authState } = useAuth();
+  const companyId = authState.companyId;
+
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<MessageState>(null);
+  const [settings, setSettings] = useState<CompanyNotificationSettings>(defaultSettings);
+
+  const canLoad = Boolean(companyId);
+
+  const visibleRows = useMemo(
+    () => settingRows,
+    [],
+  );
+
+  useEffect(() => {
+    const loadSettings = async () => {
+      if (!companyId) {
+        setLoading(false);
+        setMessage({
+          text: "No se pudo identificar la empresa actual.",
+          error: true,
+        });
+        return;
+      }
+
+      setLoading(true);
+      setMessage(null);
+
+      try {
+        const data = await getCompanyNotificationSettings(companyId);
+        setSettings(data);
+      } catch {
+        setMessage({ text: "Error al cargar las notificaciones.", error: true });
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadSettings();
+  }, [companyId]);
+
+  const updateField = (key: keyof CompanyNotificationSettingsUpdate, value: boolean) => {
+    setSettings((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!companyId) return;
+
+    setSaving(true);
+    setMessage(null);
+
+    const payload: CompanyNotificationSettingsUpdate = {
+      email_enabled: settings.email_enabled,
+      in_app_enabled: settings.in_app_enabled,
+      email_requests_created: settings.email_requests_created,
+      email_requests_status: settings.email_requests_status,
+      email_revisions: settings.email_revisions,
+      email_reservations: settings.email_reservations,
+      email_admin_alerts: settings.email_admin_alerts,
+    };
+
+    try {
+      const updated = await updateCompanyNotificationSettings(companyId, payload);
+      setSettings(updated);
+      setMessage({ text: "Configuración de notificaciones guardada.", error: false });
+    } catch {
+      setMessage({ text: "Error al guardar la configuración.", error: true });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <>
+      <GoBack />
+      <div className="flex-1 p-6 bg-[#eaeced] rounded-lg shadow-xl">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-2xl font-bold text-[var(--blue)]">Notificaciones</h2>
+          <p className="text-sm text-gray-600">
+            {companyId ? `Empresa activa: ${companyId}` : "Empresa no disponible"}
+          </p>
+        </div>
+
+        {message && (
+          <div
+            className={`mb-4 p-3 rounded-md text-sm ${
+              message.error ? "bg-red-100 text-red-700" : "bg-green-100 text-green-700"
+            }`}
+          >
+            {message.text}
+          </div>
+        )}
+
+        <section className={sectionClass}>
+          <div className="p-10">
+            <form onSubmit={handleSubmit}>
+              <div className="flex items-center justify-between mb-6">
+                <div>
+                  <h3 className="text-lg font-bold text-[var(--blue)]">Preferencias por empresa</h3>
+                  <p className="text-sm text-gray-600">Controla qué eventos generan notificaciones.</p>
+                </div>
+                <Button type="submit" disabled={!canLoad || loading || saving}>
+                  {saving ? "Guardando..." : "Guardar cambios"}
+                </Button>
+              </div>
+
+              {loading ? (
+                <div className="py-10 text-center text-gray-500">Cargando configuración...</div>
+              ) : (
+                <div className="grid gap-4 sm:grid-cols-2 sm:gap-6">
+                  {visibleRows.map((row) => {
+                    const checked = settings[row.key] ?? false;
+
+                    return (
+                      <div key={row.key} className="flex items-start justify-between gap-4 rounded-lg bg-white p-4 shadow-sm">
+                        <div>
+                          <label className={labelClass}>{row.title}</label>
+                          <p className="mt-1 text-sm text-gray-600">{row.description}</p>
+                        </div>
+                        <Switch
+                          id={row.key}
+                          checked={checked}
+                          onChange={(value) => updateField(row.key, value)}
+                          disabled={saving}
+                          srLabel={row.title}
+                        />
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </form>
+          </div>
+        </section>
+      </div>
+    </>
+  );
+}

--- a/src/pages/Admin/AdminRules.tsx
+++ b/src/pages/Admin/AdminRules.tsx
@@ -1,4 +1,14 @@
+/*
+ * FileName: AdminRules.tsx
+ * Description: Admin page for managing approval rules. Displays existing rules in a paginated table and provides a form to create new rules with fields for 
+ *              code, name, description, applicability, order, amount thresholds, required approvals, and company association. 
+ *              Includes navigation to notification settings and handles API interactions for fetching and creating rules.
+ * Authors: Original Monarca team
+ * Last Modification made:
+ * 05/05/2026 [Santiago Coronado Hernández] Added useNavigate to make button in rules section that points to notifications settings.
+ */
 import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { getRequest, postRequest } from "../../utils/apiService";
 import GoBack from "../../components/GoBack";
 import RefreshButton from "../../components/RefreshButton";
@@ -42,6 +52,7 @@ export default function AdminRules() {
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState<{ text: string; error: boolean } | null>(null);
   const [currentPage, setCurrentPage] = useState(1);
+  const navigate = useNavigate();
 
   const fetchRules = async () => {
     setLoading(true);
@@ -100,6 +111,12 @@ export default function AdminRules() {
         <div className="flex items-center justify-between mb-4">
           <h2 className="text-2xl font-bold text-[var(--blue)]">Reglas</h2>
           <div className="flex items-center gap-3">
+            <button
+              onClick={() => navigate('/admin/notifications')}
+              className="px-3 py-2 bg-[#f0f4ff] text-[#0a2c6d] text-sm rounded-md hover:bg-[#ebf0ff] transition-colors"
+            >
+              Notificaciones
+            </button>
             <button
               onClick={() => { setShowForm(!showForm); setMessage(null); }}
               className="px-4 py-2 bg-[#0a2c6d] text-white text-sm rounded-md hover:bg-[#0d3d94] transition-colors"

--- a/src/pages/Admin/__tests__/AdminNotifications.test.tsx
+++ b/src/pages/Admin/__tests__/AdminNotifications.test.tsx
@@ -1,0 +1,113 @@
+/*
+ * FileName: AdminNotifications.test.tsx
+ * Description: Test suite for AdminNotifications page. Covers loading and rendering of notification settings, toggling preferences, saving updates, and error handling when fetching settings fails.
+ * Authors: Original Monarca team
+ * Last Modification made:
+ * 05/05/2026 [Santiago Coronado Hernández] Created test file and implemented tests for AdminNotifications page covering load, update, and error scenarios.
+ */
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { BrowserRouter } from "react-router-dom";
+import "@testing-library/jest-dom";
+import AdminNotifications from "../AdminNotifications";
+import { getCompanyNotificationSettings, updateCompanyNotificationSettings } from "../../../api/companyNotificationSettings";
+
+vi.mock("../../../api/companyNotificationSettings", () => ({
+  getCompanyNotificationSettings: vi.fn(),
+  updateCompanyNotificationSettings: vi.fn(),
+}));
+
+vi.mock("../../../hooks/auth/authContext", () => ({
+  useAuth: () => ({
+    authState: {
+      companyId: "company-123",
+    },
+  }),
+}));
+
+vi.mock("../../../components/GoBack", () => ({
+  default: () => <div data-testid="go-back" />,
+}));
+
+vi.mock("../../../components/ui/Switch", () => ({
+  default: ({ checked, onChange, srLabel }: any) => (
+    <button type="button" aria-label={srLabel} onClick={() => onChange(!checked)}>
+      {checked ? "on" : "off"}
+    </button>
+  ),
+}));
+
+const baseSettings = {
+  id: "setting-1",
+  id_company: "company-123",
+  email_enabled: true,
+  in_app_enabled: false,
+  email_requests_created: true,
+  email_requests_status: true,
+  email_revisions: false,
+  email_reservations: true,
+  email_admin_alerts: false,
+};
+
+const renderPage = () => render(
+  <BrowserRouter>
+    <AdminNotifications />
+  </BrowserRouter>,
+);
+
+describe("AdminNotifications", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads and renders settings", async () => {
+    vi.mocked(getCompanyNotificationSettings).mockResolvedValue(baseSettings);
+
+    renderPage();
+
+    expect(await screen.findByText("Notificaciones")).toBeInTheDocument();
+    expect(screen.getByText("Solicitud creada")).toBeInTheDocument();
+    expect(screen.getByText("Empresa activa: company-123")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Habilitar correo" })).toHaveTextContent("on");
+    expect(screen.getByRole("button", { name: "Habilitar notificaciones internas" })).toHaveTextContent("off");
+  });
+
+  it("saves updated settings", async () => {
+    vi.mocked(getCompanyNotificationSettings).mockResolvedValue(baseSettings);
+    vi.mocked(updateCompanyNotificationSettings).mockResolvedValue({
+      ...baseSettings,
+      in_app_enabled: true,
+      email_admin_alerts: true,
+    });
+
+    renderPage();
+
+    await screen.findByText("Notificaciones");
+
+    fireEvent.click(screen.getByRole("button", { name: "Habilitar notificaciones internas" }));
+    fireEvent.click(screen.getByRole("button", { name: "Alertas administrativas" }));
+    fireEvent.click(screen.getByRole("button", { name: "Guardar cambios" }));
+
+    await waitFor(() => {
+      expect(updateCompanyNotificationSettings).toHaveBeenCalledWith("company-123", {
+        email_enabled: true,
+        in_app_enabled: true,
+        email_requests_created: true,
+        email_requests_status: true,
+        email_revisions: false,
+        email_reservations: true,
+        email_admin_alerts: true,
+      });
+    });
+
+    expect(await screen.findByText("Configuración de notificaciones guardada.")).toBeInTheDocument();
+  });
+
+  it("shows an error if loading fails", async () => {
+    vi.mocked(getCompanyNotificationSettings).mockRejectedValue(new Error("network"));
+
+    renderPage();
+
+    expect(await screen.findByText("Error al cargar las notificaciones.")).toBeInTheDocument();
+  });
+});

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -1,0 +1,31 @@
+/*
+ * FileName: notification.ts
+ * Description: TypeScript interfaces for company notification settings. Defines the structure of notification preferences for a company, including email and in-app options for various notification types related to travel requests and administrative alerts. These types are used for type safety in API interactions and state management within the frontend application.
+ * Authors: Original Monarca team
+ * Last Modification made:
+ * 05/05/2026 [Santiago Coronado Hernández] Created File to implement notification settings management for admins.
+ */
+
+export interface CompanyNotificationSettings {
+  id: string;
+  id_company: string;
+  email_enabled: boolean;
+  in_app_enabled: boolean;
+  email_requests_created: boolean;
+  email_requests_status: boolean;
+  email_revisions: boolean;
+  email_reservations: boolean;
+  email_admin_alerts: boolean;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface CompanyNotificationSettingsUpdate {
+  email_enabled?: boolean;
+  in_app_enabled?: boolean;
+  email_requests_created?: boolean;
+  email_requests_status?: boolean;
+  email_revisions?: boolean;
+  email_reservations?: boolean;
+  email_admin_alerts?: boolean;
+}


### PR DESCRIPTION
This pull request introduces a new company-level notification settings feature for admins, allowing them to manage notification preferences (email and in-app) for various company events. It includes a new admin page for notification settings, supporting API, type definitions, UI integration, and comprehensive tests. The changes also extend the authentication context to include company ID, enabling company-scoped features, and update navigation and routing to support the new functionality.

**Notification Settings Feature**

* Added a new API service (`companyNotificationSettings.ts`) for fetching and updating company notification settings, with proper TypeScript interfaces for type safety. [[1]](diffhunk://#diff-b5a4e428ac5abbbbf8ae416830a2633852064e706c0d929dc55ccc03ea3e68e8R1-R30) [[2]](diffhunk://#diff-1db5c378aec168eed9684a277ef5a3072063a03abd4f378f419caa8deb8dfc75R1-R31)
* Created the `AdminNotifications` page, allowing admins to view and update notification preferences for their company, with user feedback and error handling.
* Added a test suite for the notifications admin page, covering loading, updating, and error scenarios.

**Authentication and Context Updates**

* Extended the `AuthState` interface and authentication context to include `companyId`, and updated profile fetch logic to populate this field, enabling company-scoped features in the frontend. [[1]](diffhunk://#diff-6b7f5a2e92a93f1c5fb796ac9f8a358875065fd382d0633fb47b1c6008ae820bL6-R6) [[2]](diffhunk://#diff-6b7f5a2e92a93f1c5fb796ac9f8a358875065fd382d0633fb47b1c6008ae820bR59) [[3]](diffhunk://#diff-6b7f5a2e92a93f1c5fb796ac9f8a358875065fd382d0633fb47b1c6008ae820bR111) [[4]](diffhunk://#diff-6b7f5a2e92a93f1c5fb796ac9f8a358875065fd382d0633fb47b1c6008ae820bR138-R139) [[5]](diffhunk://#diff-6b7f5a2e92a93f1c5fb796ac9f8a358875065fd382d0633fb47b1c6008ae820bR183)

**Navigation and Routing Enhancements**

* Added a "Notificaciones" section to the sidebar for company and system admins, and updated the main router to include the new `/admin/notifications` route, protected by the company admin flag. [[1]](diffhunk://#diff-5f3a5cc0c274c553bf7e5a260f594f138c16fd5197e1555cb608f862f0120f1cL7-R7) [[2]](diffhunk://#diff-5f3a5cc0c274c553bf7e5a260f594f138c16fd5197e1555cb608f862f0120f1cR85-R87) [[3]](diffhunk://#diff-1cd8b18798a1a103bfe13bef54354c1f3a3bea29a31c8eea1a0c67a3a839b811L7-R7) [[4]](diffhunk://#diff-1cd8b18798a1a103bfe13bef54354c1f3a3bea29a31c8eea1a0c67a3a839b811R21) [[5]](diffhunk://#diff-1cd8b18798a1a103bfe13bef54354c1f3a3bea29a31c8eea1a0c67a3a839b811R147-R150)
* Updated the admin rules page to include a button that navigates to the notification settings page for easier access. [[1]](diffhunk://#diff-42f708d64c7eba446963f3de9683af6cadb644ead275f92ca64e1f16224af8b2R1-R11) [[2]](diffhunk://#diff-42f708d64c7eba446963f3de9683af6cadb644ead275f92ca64e1f16224af8b2R55) [[3]](diffhunk://#diff-42f708d64c7eba446963f3de9683af6cadb644ead275f92ca64e1f16224af8b2R114-R119)