### PR TITLE
fix(permissions): update request_history to view_own_requests in sidebar and dashboard

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -43,7 +43,7 @@ function Sidebar({ user, onNavigate }: { user: AuthState, onNavigate?: () => voi
             {user.userPermissions.includes("create_request" as Permission) && (
               <SidebarOption label="Crear solicitud" pathIcon="/assets/crear_solicitud_de_viaje.png" link="/requests/create" onClick={onNavigate}/>
             )}
-            {user.userPermissions.includes("request_history" as Permission) && (
+            {user.userPermissions.includes("view_own_requests" as Permission) && (
               <SidebarOption label="Historial de viajes" pathIcon="/assets/historial_de_viajes.png" link="/history" onClick={onNavigate}/>
             )}
             {user.userPermissions.includes("upload_vouchers" as Permission) && (

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -47,7 +47,7 @@ export const Dashboard = ({title}:DashboardProps) => {
         {authState.userPermissions.includes("create_request" as Permission) && (
           <Mosaic title="Crear solicitud de viaje" iconPath="/assets/crear_solicitud_de_viaje.png" link="/requests/create" id="create-request"/>
         )}
-        {authState.userPermissions.includes("request_history" as Permission) && (
+        {authState.userPermissions.includes("view_own_requests" as Permission) && (
           <Mosaic title="Historial de viajes" iconPath="/assets/historial_de_viajes.png" link="/history" id="history"/>
         )}
         {authState.userPermissions.includes("upload_vouchers" as Permission) && (


### PR DESCRIPTION
## Summary
- Companion fix to backend PR Equipo2-TC3004B-102/Monarca_Backend#196
- The backend replaced `request_history` with `view_own_requests` in `FLAG_PERMISSIONS` for the requester role, but the frontend was still checking for `request_history` — causing "Historial de viajes" to never render
- Updated `Sidebar.tsx` and `Dashboard.tsx` to check for `view_own_requests` instead

## ⚠️ To test this fix both repos must be on this branch
```bash
# Backend
git checkout bugfix/requester-view-own-requests-guard
npm run db:drop && npm run migration:run && npm run db:seed && npm run db:import

# Frontend
git checkout bugfix/requester-view-own-requests-guard
npm run dev
```

## Test plan
- [ ] Login as Solicitante and verify "Historial de viajes" appears in the sidebar
- [ ] Login as Solicitante and verify "Historial de viajes" appears in the dashboard mosaics
- [ ] Verify the history page loads correctly