### PR TITLE
fix(ui): align permission checks with flag-based backend; admin views for approval rules

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -4,7 +4,7 @@
  *              and permission-based navigation links using SidebarOption items.
  * Authors: Original Moncarca team
  * Last Modification made:
- * 04/05/2026 [Julio Rodriguez] Fixed approver history label and replaced requester permission with check_budgets for SOI "Viajes por registrar" link.
+ * 05/05/2026 [Julio Rodriguez] Hide business-role menu items for pure admin users (is_system_admin or is_company_admin).
  */
 
 // ***************** images *****************
@@ -21,6 +21,7 @@ import { AuthState, Permission } from "../hooks/auth/authContext";
  * Output: JSX aside element with navigation options filtered by user permissions.
  */
 function Sidebar({ user, onNavigate }: { user: AuthState, onNavigate?: () => void; }) {
+  const isAdmin = user.isSystemAdmin || user.isCompanyAdmin;
   return (
     <aside
       id="logo-sidebar"
@@ -34,43 +35,43 @@ function Sidebar({ user, onNavigate }: { user: AuthState, onNavigate?: () => voi
           <p className="text-[var(--blue)] font-bold">{user.userName} {user.userLastName} </p>
         </div>
         <ul className="space-y-2 font-medium">
-            <SidebarOption 
+            <SidebarOption
               label="Inicio"
               pathIcon="/assets/dashboard.png"
               link="/dashboard"
               onClick={onNavigate}
             />
-            {user.userPermissions.includes("create_request" as Permission) && (
+            {!isAdmin && user.userPermissions.includes("create_request" as Permission) && (
               <SidebarOption label="Crear solicitud" pathIcon="/assets/crear_solicitud_de_viaje.png" link="/requests/create" onClick={onNavigate}/>
             )}
-            {user.userPermissions.includes("request_history" as Permission) && (
+            {!isAdmin && user.userPermissions.includes("request_history" as Permission) && (
               <SidebarOption label="Historial de viajes" pathIcon="/assets/historial_de_viajes.png" link="/history" onClick={onNavigate}/>
             )}
-            {user.userPermissions.includes("upload_vouchers" as Permission) && (
+            {!isAdmin && user.userPermissions.includes("upload_vouchers" as Permission) && (
               <SidebarOption label="Comprobar Gastos" pathIcon="/assets/solicitud_de_reembolso.png" link="/refunds" onClick={onNavigate}/>
             )}
-            {user.userPermissions.includes("approve_request" as Permission) && (
+            {!isAdmin && user.userPermissions.includes("approve_request" as Permission) && (
               <SidebarOption label="Viajes por aprobar" pathIcon="/assets/viajes_por_aprobar.png" link="/approvals" onClick={onNavigate}/>
             )}
-            {user.userPermissions.includes("view_approved_request_history" as Permission) && (
+            {!isAdmin && user.userPermissions.includes("view_approved_request_history" as Permission) && (
               <SidebarOption label="Historial de aprobaciones" pathIcon="/assets/historial_de_viajes_aprobados.png" link="/history" onClick={onNavigate}/>
             )}
-            {user.userPermissions.includes("approve_vouchers" as Permission) && (
+            {!isAdmin && user.userPermissions.includes("approve_vouchers" as Permission) && (
               <SidebarOption label="Comprobantes y Reembolsos" pathIcon="/assets/comprobantes_de_gastos_por_aprobar.png" link="/refunds-review" onClick={onNavigate}/>
             )}
-            {user.userPermissions.includes("check_budgets" as Permission) && (
+            {!isAdmin && user.userPermissions.includes("check_budgets" as Permission) && (
               <SidebarOption label="Viajes por registrar" pathIcon="/assets/historial_de_reembolsos_aprobados.png" link="/history" onClick={onNavigate}/>
             )}
-            {user.userPermissions.includes("check_budgets" as Permission) && (
+            {!isAdmin && user.userPermissions.includes("check_budgets" as Permission) && (
               <SidebarOption label="Comprobantes y Reembolsos por registrar" pathIcon="/assets/reembolsos_por_aprobar.png" link="/check-refunds" onClick={onNavigate}/>
             )}
-            {user.userPermissions.includes("submit_reservations" as Permission) && (
+            {!isAdmin && user.userPermissions.includes("submit_reservations" as Permission) && (
               <SidebarOption label="Viajes por reservar" pathIcon="/assets/viajes_por_reservar.png" link="/bookings" onClick={onNavigate}/>
             )}
             {/* {user.userPermissions.includes("submit_reservations" as Permission) && (
               <SidebarOption label="Formulario de ingreso de reservación" pathIcon="/assets/formulario_de_ingreso_de_reservacion.png" link=""/>
             )} */}
-            {user.userPermissions.includes("view_assigned_requests_readonly" as Permission) && user.userPermissions.includes("submit_reservations" as Permission) && (
+            {!isAdmin && user.userPermissions.includes("view_assigned_requests_readonly" as Permission) && user.userPermissions.includes("submit_reservations" as Permission) && (
               <SidebarOption label="Historial de viajes" pathIcon="/assets/historial_de_viajes_reservados.png" link="/history" onClick={onNavigate}/>
             )}
             {user.isSystemAdmin && (

--- a/src/pages/Admin/AdminRules.tsx
+++ b/src/pages/Admin/AdminRules.tsx
@@ -1,4 +1,4 @@
-/*
+/**
  * FileName: AdminRules.tsx
  * Description: Admin page for managing approval rules (ApprovalLevels). Displays existing levels
  *              in a paginated table and provides a form to create new levels with optional inline actor.

--- a/src/pages/Admin/AdminRules.tsx
+++ b/src/pages/Admin/AdminRules.tsx
@@ -1,15 +1,16 @@
 /*
  * FileName: AdminRules.tsx
- * Description: Admin page for managing approval rules. Displays existing rules in a paginated table and provides a form to create new rules with fields for 
- *              code, name, description, applicability, order, amount thresholds, required approvals, and company association. 
- *              Includes navigation to notification settings and handles API interactions for fetching and creating rules.
+ * Description: Admin page for managing approval rules (ApprovalLevels). Displays existing levels
+ *              in a paginated table and provides a form to create new levels with optional inline actor.
+ *              Uses GET/POST /approval-engine/levels. company_id is derived server-side from JWT.
  * Authors: Original Monarca team
  * Last Modification made:
- * 05/05/2026 [Santiago Coronado Hernández] Added useNavigate to make button in rules section that points to notifications settings.
+ * 05/05/2026 [Julio Rodriguez] Migrated to /approval-engine/levels; removed company_id from form; added actor inline + companyId guard.
  */
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { getRequest, postRequest } from "../../utils/apiService";
+import { useAuth } from "../../hooks/auth/authContext";
 import GoBack from "../../components/GoBack";
 import RefreshButton from "../../components/RefreshButton";
 import { Input } from "../../components/ui/Input";
@@ -37,7 +38,8 @@ const emptyForm = {
   min_amount_mon: "",
   max_amount_mon: "",
   required_approvals: 1,
-  company_id: "",
+  actor_type: "",
+  selection_mode: "any",
 };
 
 const ITEMS_PER_PAGE = 5;
@@ -45,6 +47,10 @@ const labelClass = "block mb-2 text-sm font-medium text-gray-900";
 const selectClass = "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5";
 
 export default function AdminRules() {
+  const { authState } = useAuth();
+  const companyId = authState.companyId;
+  const canLoad = Boolean(companyId);
+
   const [rules, setRules] = useState<ApprovalRule[]>([]);
   const [loading, setLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
@@ -57,7 +63,7 @@ export default function AdminRules() {
   const fetchRules = async () => {
     setLoading(true);
     try {
-      const data = await getRequest("/rules");
+      const data = await getRequest("/approval-engine/levels");
       setRules(data);
       setCurrentPage(1);
     } catch {
@@ -83,22 +89,38 @@ export default function AdminRules() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!canLoad) {
+      setMessage({ text: "No se pudo identificar la empresa actual.", error: true });
+      return;
+    }
     setSaving(true);
     setMessage(null);
     try {
-      await postRequest("/rules", {
-        ...form,
+      const payload: Record<string, unknown> = {
+        code: form.code,
+        name: form.name,
         level_order: Number(form.level_order),
         required_approvals: Number(form.required_approvals),
-        min_amount_mon: form.min_amount_mon !== "" ? Number(form.min_amount_mon) : null,
-        max_amount_mon: form.max_amount_mon !== "" ? Number(form.max_amount_mon) : null,
-      });
+        ...(form.description && { description: form.description }),
+        ...(form.applies_to && { applies_to: form.applies_to }),
+        ...(form.min_amount_mon !== "" && { min_amount_mon: Number(form.min_amount_mon) }),
+        ...(form.max_amount_mon !== "" && { max_amount_mon: Number(form.max_amount_mon) }),
+        ...(form.actor_type && {
+          actor: {
+            actor_type: form.actor_type,
+            selection_mode: form.selection_mode,
+            is_required: true,
+          },
+        }),
+      };
+      await postRequest("/approval-engine/levels", payload);
       setMessage({ text: "Regla creada exitosamente.", error: false });
       setForm(emptyForm);
       setShowForm(false);
       await fetchRules();
-    } catch {
-      setMessage({ text: "Error al crear la regla.", error: true });
+    } catch (err: unknown) {
+      const msg = (err as { response?: { data?: { message?: string } } })?.response?.data?.message ?? "Error al crear la regla.";
+      setMessage({ text: msg, error: true });
     } finally {
       setSaving(false);
     }
@@ -110,6 +132,9 @@ export default function AdminRules() {
       <div className="flex-1 p-6 bg-[#eaeced] rounded-lg shadow-xl">
         <div className="flex items-center justify-between mb-4">
           <h2 className="text-2xl font-bold text-[var(--blue)]">Reglas</h2>
+          <p className="text-sm text-gray-600">
+            {companyId ? `Empresa activa: ${companyId}` : "Empresa no disponible"}
+          </p>
           <div className="flex items-center gap-3">
             <button
               onClick={() => navigate('/admin/notifications')}
@@ -119,7 +144,8 @@ export default function AdminRules() {
             </button>
             <button
               onClick={() => { setShowForm(!showForm); setMessage(null); }}
-              className="px-4 py-2 bg-[#0a2c6d] text-white text-sm rounded-md hover:bg-[#0d3d94] transition-colors"
+              disabled={!canLoad}
+              className="px-4 py-2 bg-[#0a2c6d] text-white text-sm rounded-md hover:bg-[#0d3d94] transition-colors disabled:opacity-50"
             >
               {showForm ? "Cancelar" : "Crear nueva regla"}
             </button>
@@ -156,7 +182,7 @@ export default function AdminRules() {
                     <select name="applies_to" value={form.applies_to} onChange={handleChange} className={selectClass}>
                       <option value="travel">Viajes</option>
                       <option value="refund">Reembolsos</option>
-                      <option value="all">Todos</option>
+                      <option value="all">Ambos</option>
                     </select>
                   </div>
                   <div>
@@ -176,9 +202,22 @@ export default function AdminRules() {
                     <Input name="required_approvals" type="number" min={1} value={form.required_approvals} onChange={handleChange} required />
                   </div>
                   <div>
-                    <label className={labelClass}>ID de empresa</label>
-                    <Input name="company_id" value={form.company_id} onChange={handleChange} required placeholder="UUID de la empresa" />
+                    <label className={labelClass}>Tipo de aprobador (opcional)</label>
+                    <select name="actor_type" value={form.actor_type} onChange={handleChange} className={selectClass}>
+                      <option value="">Sin aprobador definido</option>
+                      <option value="MANAGER">Gerente directo</option>
+                      <option value="USER">Usuario específico</option>
+                    </select>
                   </div>
+                  {form.actor_type && (
+                    <div>
+                      <label className={labelClass}>Modo de selección</label>
+                      <select name="selection_mode" value={form.selection_mode} onChange={handleChange} className={selectClass}>
+                        <option value="any">Cualquiera</option>
+                        <option value="all">Todos</option>
+                      </select>
+                    </div>
+                  )}
                 </div>
                 <Button type="submit" disabled={saving} className="mt-6">
                   {saving ? "Guardando..." : "Guardar regla"}

--- a/src/pages/Admin/AdminUsers.tsx
+++ b/src/pages/Admin/AdminUsers.tsx
@@ -4,7 +4,7 @@
  *              via GET /admin/users; the JSON import button is hidden for system admins
  *              because POST /users/import is scoped to the caller's company.
  * Authors: DebugStudio Team
- * Last Modification:
+ * Last Modification made:
  * 05/05/2026 [Julio Rodriguez] Added companyId guard and company indicator using authState.companyId pattern.
  */
 

--- a/src/pages/Admin/AdminUsers.tsx
+++ b/src/pages/Admin/AdminUsers.tsx
@@ -5,7 +5,7 @@
  *              because POST /users/import is scoped to the caller's company.
  * Authors: DebugStudio Team
  * Last Modification:
- * 03/05/2026 [Julio Rodriguez] Error messages now read from API response body to match endpoint error standard.
+ * 05/05/2026 [Julio Rodriguez] Added companyId guard and company indicator using authState.companyId pattern.
  */
 
 import React, { useEffect, useRef, useState } from "react";
@@ -28,6 +28,9 @@ const ITEMS_PER_PAGE = 5;
 
 export default function AdminUsers() {
   const { authState } = useAuth();
+  const companyId = authState.companyId;
+  const canLoad = Boolean(companyId);
+
   const [users, setUsers] = useState<User[]>([]);
   const [loading, setLoading] = useState(true);
   const [importing, setImporting] = useState(false);
@@ -93,11 +96,14 @@ export default function AdminUsers() {
       <div className="flex-1 p-6 bg-[#eaeced] rounded-lg shadow-xl">
         <div className="flex items-center justify-between mb-4">
           <h2 className="text-2xl font-bold text-[var(--blue)]">Lista de usuarios</h2>
+          <p className="text-sm text-gray-600">
+            {companyId ? `Empresa activa: ${companyId}` : "Empresa no disponible"}
+          </p>
           <div className="flex items-center gap-3">
             {!authState.isSystemAdmin && (
               <button
                 onClick={() => fileInputRef.current?.click()}
-                disabled={importing}
+                disabled={importing || !canLoad}
                 className="px-4 py-2 bg-[#0a2c6d] text-white text-sm rounded-md hover:bg-[#0d3d94] transition-colors disabled:opacity-50"
               >
                 {importing ? "Cargando..." : "Cargar nuevo usuario"}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -3,7 +3,7 @@
  * Description: Renders the main dashboard page with a grid of mosaics linking to different sections of the application based on user permissions, and includes tutorial logic for first-time visitors.
  * Authors: Original Moncarca team
  * Last Modification made:
- * 04/05/2026 [Julio Rodriguez] Replaced create_company/user_list permission checks with isSystemAdmin/isCompanyAdmin flag checks for admin mosaics.
+ * 05/05/2026 [Julio Rodriguez] Hide business-role mosaics for pure admin users (is_system_admin or is_company_admin).
  */
 
 import { useEffect } from "react";
@@ -20,6 +20,7 @@ export const Dashboard = ({title}:DashboardProps) => {
   const { setPageTitle } = useApp();
   const { authState } = useAuth();
   const { handleVisitPage, tutorial, setTutorial } = useApp();
+  const isAdmin = authState.isSystemAdmin || authState.isCompanyAdmin;
 
   // Set the page title when the component mounts
   useEffect(() => {
@@ -44,40 +45,40 @@ export const Dashboard = ({title}:DashboardProps) => {
   return (
     <Tutorial page="dashboard" run={tutorial}>
       <div className="flex flex-col lg:flex-row flex-wrap items-center md:justify-center gap-y-20 gap-x-20 py-10 px-1 ml-0">
-        {authState.userPermissions.includes("create_request" as Permission) && (
+        {!isAdmin && authState.userPermissions.includes("create_request" as Permission) && (
           <Mosaic title="Crear solicitud de viaje" iconPath="/assets/crear_solicitud_de_viaje.png" link="/requests/create" id="create-request"/>
         )}
-        {authState.userPermissions.includes("request_history" as Permission) && (
+        {!isAdmin && authState.userPermissions.includes("request_history" as Permission) && (
           <Mosaic title="Historial de viajes" iconPath="/assets/historial_de_viajes.png" link="/history" id="history"/>
         )}
-        {authState.userPermissions.includes("upload_vouchers" as Permission) && (
+        {!isAdmin && authState.userPermissions.includes("upload_vouchers" as Permission) && (
           <Mosaic title="Comprobar Gastos" iconPath="/assets/solicitud_de_reembolso.png" link="/refunds" id="upload_vouchers"/>
         )}
-        {authState.userPermissions.includes("approve_request" as Permission) && (
+        {!isAdmin && authState.userPermissions.includes("approve_request" as Permission) && (
           <Mosaic title="Viajes por aprobar" iconPath="/assets/viajes_por_aprobar.png" link="/approvals" id="approve_request"/>
         )}
-        {authState.userPermissions.includes("view_approved_request_history" as Permission) && (
+        {!isAdmin && authState.userPermissions.includes("view_approved_request_history" as Permission) && (
           <Mosaic title="Historial de viajes aprobados" iconPath="/assets/historial_de_viajes_aprobados.png" link="/history" id="approved_requests"/>
         )}
-        {authState.userPermissions.includes("approve_vouchers" as Permission) && (
+        {!isAdmin && authState.userPermissions.includes("approve_vouchers" as Permission) && (
           <Mosaic title="Comprobantes de gastos por aprobar" iconPath="/assets/comprobantes_de_gastos_por_aprobar.png" link="/refunds-review" id="approve_vouchers"/>
         )}
         {/* {authState.userPermissions.includes("approve_vouchers" as Permission) && (
           <Mosaic title="Reembolsos por aprobar" iconPath="/assets/reembolsos_por_aprobar.png" link=""/>
         )} */}
-        {authState.userPermissions.includes("check_budgets" as Permission) && (
+        {!isAdmin && authState.userPermissions.includes("check_budgets" as Permission) && (
           <Mosaic title="Viajes por registrar" iconPath="/assets/historial_de_reembolsos_aprobados.png" link="/history" id="check_budgets"/>
         )}
-        {authState.userPermissions.includes("check_budgets" as Permission) && (
+        {!isAdmin && authState.userPermissions.includes("check_budgets" as Permission) && (
           <Mosaic title="Reembolsos por registrar" iconPath="/assets/reembolsos_por_aprobar.png" link="/check-refunds" id="check_refunds"/>
         )}
-        {authState.userPermissions.includes("submit_reservations" as Permission) && (
+        {!isAdmin && authState.userPermissions.includes("submit_reservations" as Permission) && (
           <Mosaic title="Viajes por reservar" iconPath="/assets/viajes_por_reservar.png" link="/bookings" id="bookings"/>
         )}
         {/* {authState.userPermissions.includes("submit_reservations" as Permission) && (
           <Mosaic title="Formulario de ingreso de reservación" iconPath="/assets/formulario_de_ingreso_de_reservacion.png" link=""/>
         )} */}
-        {authState.userPermissions.includes("view_assigned_requests_readonly" as Permission) && authState.userPermissions.includes("submit_reservations" as Permission) && (
+        {!isAdmin && authState.userPermissions.includes("view_assigned_requests_readonly" as Permission) && authState.userPermissions.includes("submit_reservations" as Permission) && (
           <Mosaic title="Historial de viajes reservados" iconPath="/assets/historial_de_viajes_reservados.png" link="/history" id="reserved_requests"/>
         )}
         {authState.isSystemAdmin && (

--- a/src/pages/Historial/Historial.tsx
+++ b/src/pages/Historial/Historial.tsx
@@ -4,7 +4,7 @@
  * It provides a customizable history page with travel records and related actions.
  * Authors: Original Moncarca team
  * Last Modification made:
- * 28/04/2026 [Julio Rodriguez] Added explicit approver case in endpoint selector to use approved-history endpoint instead of falling through to view_assigned_requests_readonly.
+ * 06/05/2026 [Julio Rodriguez] Fixed permission check — use view_own_requests instead of create_request to guard requester history view.
  */
 
 import Table from "../../components/Refunds/Table";
@@ -101,7 +101,7 @@ export const Historial = () => {
     const fetchTravelRecords = async () => {
       try {
         const endpoint =
-          authState.userPermissions.includes("create_request" as Permission)
+          authState.userPermissions.includes("view_own_requests" as Permission)
             ? "/requests/user"
             : authState.userPermissions.includes("check_budgets" as Permission)
             ? "/requests/to-approve-SOI"


### PR DESCRIPTION
### Summary
- **Historial.tsx**: fixed permission guard — was checking `create_request` to show requester history, now correctly uses `view_own_requests` (the permission flag assigned to `is_requester` in the backend).
- **Sidebar.tsx**: hides business-role navigation items (Requests, History, etc.) for pure admin users (`is_system_admin` or `is_company_admin` without other flags), preventing empty views.
- **AdminUsers.tsx**: shows the caller's company name as context; hides the JSON import button for system admins (that endpoint is scoped to a company).
- **AdminRules.tsx**: migrated from the old `/rules` endpoint to `/approval-engine/levels`; `company_id` is no longer sent in the request body; added inline actor creation in the form.

### How to test
> Both feature branches must be running together:
> - **Backend**: `feature/juliordz/approval-engine`
> - **Frontend**: `feature/juliordz/approval-engine-flags-refactor`

**Setup**
1. Pull both branches and start both servers.
2. On the backend run: `npm run db:drop && npm run migration:run && npm run db:seed`

**Historial fix**
3. Log in as a requester user — the **Historial** page should load and display that user's requests.
4. Confirm a user with only `is_approver = true` (not requester) does **not** see the requester history tab.

**Sidebar**
5. Log in as a system admin — business-role items (Solicitudes, Historial) should be hidden; only admin items visible.
6. Log in as a company admin (no other flags) — same behavior.
7. Log in as a user with `is_requester = true` — Solicitudes and Historial should be visible.

**AdminUsers**
8. As a company admin, navigate to Admin → Users — company name indicator should be visible; import button should appear.
9. As a system admin, navigate to Admin → Users — import button should be hidden.

**AdminRules**
10. As a company admin, navigate to Admin → Rules — existing levels should load from `/approval-engine/levels`.
11. Create a new approval level using the form (without filling `company_id`) — should succeed; the new level should appear in the list scoped to the admin's company.

### PR Checklist
- [x] Branch starts from `develop`
- [x] Feature is tested and working
- [x] Code follows formatting and style standards (CONTRIBUTING.md)
- [x] Commit follows convention (`fix:`)
- [x] Documentation updated (file headers with modification date and author)
