### PR TITLE
fix: approvals table responsiveness and language toggle on login

### DIFF
--- a/src/components/Approvals/Table.tsx
+++ b/src/components/Approvals/Table.tsx
@@ -17,6 +17,7 @@ import { useTranslation } from "react-i18next";
 interface Column {
   key: string;
   header: string;
+  mobileHidden?: boolean;
   render?: (value: any) => ReactNode;
 }
 
@@ -93,7 +94,7 @@ const Table: React.FC<TableProps> = ({
   return (
     <div className="relative">
       <div className="overflow-x-auto mb-4">
-        <table className="w-full table-fixed text-sm text-left rtl:text-right text-gray-500 dark:text-gray-400 border-separate border-spacing-y-2">
+        <table className="w-full min-w-[900px] table-fixed text-sm text-left rtl:text-right text-gray-500 dark:text-gray-400 border-separate border-spacing-y-2">
           <thead>
             <tr className="text-xs text-white uppercase bg-[#0a2c6d]">
               {columns.map((column, index) => (
@@ -101,19 +102,17 @@ const Table: React.FC<TableProps> = ({
                   key={index}
                   className={`px-4 py-2 text-center ${
                     index === 0 ? "rounded-l-lg" : ""
-                  } ${
-                    index === columns.length - 1 ? "" : ""
-                  }`}
+                  } ${column.mobileHidden ? "hidden lg:table-cell" : ""}`}
                 >
                   {column.header}
                 </th>
               ))}
 
-              <th className="px-4 py-2 text-center border-r border-[#0a2c6d] w-[120px]">
+              <th className="px-4 py-2 text-center">
                 {t('approvals.details')}
               </th>
 
-              <th className="px-4 py-2 text-center rounded-r-lg w-[80px]">{t('approvals.data')}</th>
+              <th className="px-4 py-2 text-center rounded-r-lg">{t('approvals.data')}</th>
             </tr>
           </thead>
 
@@ -133,10 +132,8 @@ const Table: React.FC<TableProps> = ({
                       className={`py-3 ${
                         cidx === 0 ? "rounded-l-lg" : ""
                       } ${
-                        cidx === columns.length - 1 ? "" : ""
-                      } ${
                         column.key === "status" ? "px-0" : "px-4"
-                    }`}
+                      } ${column.mobileHidden ? "hidden lg:table-cell" : ""}`}
                     >
                       {row[column.key] !== undefined && row[column.key] !== null
                         ? column.render
@@ -172,7 +169,7 @@ const Table: React.FC<TableProps> = ({
                       colSpan={columns.length + 2}
                       className="bg-[var(--color-page-bg)] text-[var(--color-page-text)] p-4 rounded-b-lg"
                     >
-                      <div className="grid grid-cols-3 gap-6">
+                      <div className="grid grid-cols-3 gap-4">
                         <div>
                           <strong>{t('approvals.requester')}:</strong>{" "}
                           {`${row?.user?.name} ${row?.user?.last_name}`}

--- a/src/components/DarkLightButton.tsx
+++ b/src/components/DarkLightButton.tsx
@@ -26,7 +26,7 @@ export default function DarkModeButton({ className = "", classNameText = ""}: Pr
   };
 
   return (
-    <div className={`flex flex-col gap-1 w-[6rem] items-center ${className}`}>
+    <div className={`flex flex-col gap-1 w-[5rem] items-center ${className}`}>
       <span className={`${classNameText || "text-[var(--color-page-text)]"}`} style={{fontSize: '13px', fontWeight: 'bold'}}>{isDark ? t('theme.dark') : t('theme.light')}</span>
       <Switch
       checked={isDark}

--- a/src/components/DarkLightButton.tsx
+++ b/src/components/DarkLightButton.tsx
@@ -1,5 +1,6 @@
 import Switch from "./ui/Switch";
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 
 interface Props {
   className?: string;
@@ -8,6 +9,7 @@ interface Props {
 
 export default function DarkModeButton({ className = "", classNameText = ""}: Props) {
   const [isDark, setIsDark] = useState(false);
+  const { t } = useTranslation();
 
   useEffect(() => {
     const savedTheme = localStorage.getItem("theme");
@@ -24,9 +26,9 @@ export default function DarkModeButton({ className = "", classNameText = ""}: Pr
   };
 
   return (
-    <div className={`flex flex-col gap-1 ${className}`}>
-      <span className={`${classNameText || "text-[var(--color-page-text)]"}`} style={{fontSize: '13px', fontWeight: 'bold'}}>{isDark ? "Modo oscuro" : "Modo claro"}</span>
-      <Switch 
+    <div className={`flex flex-col gap-1 w-[6rem] items-center ${className}`}>
+      <span className={`${classNameText || "text-[var(--color-page-text)]"}`} style={{fontSize: '13px', fontWeight: 'bold'}}>{isDark ? t('theme.dark') : t('theme.light')}</span>
+      <Switch
       checked={isDark}
       onChange={handleThemeChange}
       srLabel="Cambiar modo oscuro"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -50,12 +50,12 @@ function Header({ toggleSidebar }: { toggleSidebar: () => void }) {
           <div className="flex items-center">
             <div className="flex items-center ms-3 relative">
               <div className="flex items-center gap-4">
-                <DarkModeButton className="hidden md:flex md:items-center" classNameText="#f9fafb"></DarkModeButton>
+                <DarkModeButton className="hidden md:flex md:items-center -mt-2" classNameText="#f9fafb"></DarkModeButton>
                 <button
                   type="button"
                   title={i18n.language === 'es' ? 'Switch to English' : 'Cambiar a Español'}
                   onClick={toggleLanguage}
-                  className="hidden md:block hover:scale-110 transition-transform"
+                  className="hidden md:block hover:scale-110 transition-transform mt-1"
                 >
                   <img
                     src={i18n.language === 'es' ? '/assets/flag_mx.svg' : '/assets/flag_us.svg'}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -105,7 +105,7 @@ function Sidebar({ user, onNavigate }: { user: AuthState, onNavigate?: () => voi
               type="button"
               title={i18n.language === 'es' ? 'Switch to English' : 'Cambiar a Español'}
               onClick={toggleLanguage}
-              className="block md:hidden hover:scale-110 transition-transform"
+              className="block md:hidden hover:scale-110 transition-transform mt-3"
             >
               <img
                 src={i18n.language === 'es' ? '/assets/flag_mx.svg' : '/assets/flag_us.svg'}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -588,5 +588,9 @@
       "adminAlerts": "Administrative alerts",
       "adminAlertsDesc": "Notifies by email about relevant administrative events."
     }
+  },
+  "theme": {
+    "dark": "Dark mode",
+    "light": "Light mode"
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -588,5 +588,9 @@
       "adminAlerts": "Alertas administrativas",
       "adminAlertsDesc": "Notifica por email eventos administrativos relevantes."
     }
+  },
+  "theme": {
+    "dark": "Modo oscuro",
+    "light": "Modo claro"
   }
 }

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -120,7 +120,7 @@ export default function LoginPage() {
     >
       <div className="w-[90%] lg:w-[45%] bg-[url('/imageLogin.png')] bg-center bg-cover bg-no-repeat rounded-[15px] h-[10%] lg:h-[95%] m-[2vh]"></div>
       <div className="w-[100%] lg:w-[55%] flex flex-col justify-center items-center p-12 relative">
-      <div className="absolute top-7 lg:top-8 right-12 z-50 flex items-center gap-4">
+      <div className="absolute top-7 lg:top-8 right-6 lg:right-12 z-50 flex items-center gap-4 lg:gap-4">
         <DarkModeButton className="flex items-center -mt-4"></DarkModeButton>
         <button
           type="button"

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -38,7 +38,12 @@ interface User {
  */
 export default function LoginPage() {
   const navigate = useNavigate();
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const toggleLanguage = () => {
+    const next = i18n.language === 'es' ? 'en' : 'es';
+    i18n.changeLanguage(next);
+    localStorage.setItem('language', next);
+  };
   const [user, setUser] = useState<User>({
     email: "",
     password: "",
@@ -115,13 +120,27 @@ export default function LoginPage() {
     >
       <div className="w-[90%] lg:w-[45%] bg-[url('/imageLogin.png')] bg-center bg-cover bg-no-repeat rounded-[15px] h-[10%] lg:h-[95%] m-[2vh]"></div>
       <div className="w-[100%] lg:w-[55%] flex flex-col justify-center items-center p-12 relative">
-      <DarkModeButton className="items-center absolute top-7 lg:top-8 right-60 lg:right-75 z-50"></DarkModeButton>
+      <div className="absolute top-7 lg:top-8 right-12 z-50 flex items-center gap-4">
+        <DarkModeButton className="flex items-center -mt-4"></DarkModeButton>
+        <button
+          type="button"
+          title={i18n.language === 'es' ? 'Switch to English' : 'Cambiar a Español'}
+          onClick={toggleLanguage}
+          className="hover:scale-110 transition-transform mt-1"
+        >
+          <img
+            src={i18n.language === 'es' ? '/assets/flag_mx.svg' : '/assets/flag_us.svg'}
+            alt={i18n.language === 'es' ? 'Español' : 'English'}
+            className="w-12 h-8 rounded-sm object-cover shadow-sm"
+          />
+        </button>
         <p
-          className="text-[2rem] lg:text-[2.5rem] absolute top-8 right-12 dark:text-[var(--color-page-text)]"
+          className="text-[2rem] lg:text-[2.5rem] dark:text-[var(--color-page-text)]"
           style={{ fontWeight: 700 }}
         >
           <span className="text-[#0466CB]">M</span>ONARCA
         </p>
+      </div>
         <ToastContainer />
         <h1
           className="text-[2.5rem] lg:text-[3.5rem] text-[var(--color-page-text-title)] dark:text-[var(--color-page-text-title)] text-center mb-8 mt-20"


### PR DESCRIPTION
## Summary
- Fix approvals table mobile scroll and desktop column spacing
- Add language toggle button to login page alongside dark mode button
- Fix dark mode button text to respond to language changes and stop shifting on toggle

## Test plan
- [ ] Approvals table scrolls correctly on mobile without empty space
- [ ] Approvals table columns are evenly distributed on desktop
- [ ] Login page shows flag + dark mode button in correct order
- [ ] Changing language on login page works correctly
- [ ] Dark mode button text updates when switching language