### PR TITLE
fix: prevent dark/light mode label from wrapping to two lines

### DIFF
--- a/src/components/DarkLightButton.tsx
+++ b/src/components/DarkLightButton.tsx
@@ -26,8 +26,8 @@ export default function DarkModeButton({ className = "", classNameText = ""}: Pr
   };
 
   return (
-    <div className={`flex flex-col gap-1 w-[5rem] items-center ${className}`}>
-      <span className={`${classNameText || "text-[var(--color-page-text)]"}`} style={{fontSize: '13px', fontWeight: 'bold'}}>{isDark ? t('theme.dark') : t('theme.light')}</span>
+    <div className={`flex flex-col gap-1 w-[6.5rem] items-center ${className}`}>
+      <span className={`whitespace-nowrap ${classNameText || "text-[var(--color-page-text)]"}`} style={{fontSize: '13px', fontWeight: 'bold'}}>{isDark ? t('theme.dark') : t('theme.light')}</span>
       <Switch
       checked={isDark}
       onChange={handleThemeChange}


### PR DESCRIPTION
## Summary
- Increased `DarkLightButton` container width from `w-[5rem]` to `w-[6.5rem]` to fit the translated label
- Added `whitespace-nowrap` to the label span so "Modo oscuro" / "Light mode" always renders on a single line

## Test plan
- [ ] Verify on the login page that the dark/light mode button label does not wrap in Spanish
- [ ] Verify the same in English ("Light mode" / "Dark mode")
- [ ] Confirm the button does not shift horizontally when toggling between modes