### PR TITLE
feat(flights): integrate Duffel search and sequential dates

### DIFF
--- a/src/components/flights/FlightCard.tsx
+++ b/src/components/flights/FlightCard.tsx
@@ -3,7 +3,7 @@
  * Description: Individual flight offer card showing details, price, airline and segments.
  * Authors: Debug Studio (Diego de la Vega)
  * Last Modification made:
- * 12/05/2026 [Diego de la Vega] Created FlightCard component.
+ * 14/05/2026 [Diego de la Vega] Added Duffel provider and some dark mode buttons.
  */
 
 import { UnifiedFlightOption } from '../../hooks/flights/useFlightSearch';
@@ -36,19 +36,19 @@ export default function FlightCard({ flight, onSelect, selectLabel }: FlightCard
   };
 
   return (
-    <div className="bg-white border border-gray-200 rounded-lg shadow hover:shadow-lg transition overflow-hidden">
+    <div className="bg-[var(--color-card-bg)] border border-[var(--color-border)] rounded-lg shadow hover:shadow-lg transition overflow-hidden">
       {/* Header */}
-      <div className="p-6 bg-gradient-to-r from-blue-50 to-indigo-50">
+      <div className="p-6 bg-[var(--color-page-bg)] border-b border-[var(--color-border)]">
         <div className="flex justify-between items-start mb-4">
           <div>
-            <h3 className="text-lg font-bold text-gray-900">{flight.airline || 'Airline'}</h3>
-            <p className="text-sm text-gray-600">
+            <h3 className="text-lg font-bold text-[var(--color-page-text-title)]">{flight.airline || 'Airline'}</h3>
+            <p className="text-sm text-[var(--color-page-text)]">
               {flight.stops === 0 ? 'Vuelo directo' : `${flight.stops} parada${flight.stops !== 1 ? 's' : ''}`}
             </p>
           </div>
           <div className="text-right">
-            <p className="text-2xl font-bold text-blue-600">{formatPrice(flight.total_price_mxn)}</p>
-            <p className="text-xs text-gray-500">
+            <p className="text-2xl font-bold text-[var(--blue)]">{formatPrice(flight.total_price_mxn)}</p>
+            <p className="text-xs text-[var(--color-page-text)]">
               {formatPrice(flight.original_price, flight.original_currency)}
             </p>
           </div>
@@ -56,30 +56,30 @@ export default function FlightCard({ flight, onSelect, selectLabel }: FlightCard
       </div>
 
       {/* Segments Preview */}
-      <div className="px-6 py-4 border-t border-gray-200">
+      <div className="px-6 py-4 border-t border-[var(--color-border)]">
         {flight.segments.map((segment, idx) => (
-          <div key={idx} className={`flex items-center justify-between ${idx > 0 ? 'mt-4 pt-4 border-t border-gray-100' : ''}`}>
+          <div key={idx} className={`flex items-center justify-between ${idx > 0 ? 'mt-4 pt-4 border-t border-[var(--color-border)]' : ''}`}>
             <div className="flex-1">
-              <p className="font-semibold text-gray-900">
+              <p className="font-semibold text-[var(--color-page-text-title)]">
                 {segment.origin_airport_code} → {segment.destination_airport_code}
               </p>
-              <p className="text-sm text-gray-600">
+              <p className="text-sm text-[var(--color-page-text)]">
                 {segment.origin_city} a {segment.destination_city}
               </p>
             </div>
             <div className="text-right">
-              <p className="font-mono text-sm text-gray-900">{formatTime(segment.departure_at)}</p>
-              <p className="text-xs text-gray-500">Salida</p>
+              <p className="font-mono text-sm text-[var(--color-page-text-title)]">{formatTime(segment.departure_at)}</p>
+              <p className="text-xs text-[var(--color-page-text)]">Salida</p>
             </div>
           </div>
         ))}
       </div>
 
       {/* Footer */}
-      <div className="px-6 py-4 bg-gray-50 border-t border-gray-200 flex gap-3">
+      <div className="px-6 py-4 bg-[var(--color-card-bg)] border-t border-[var(--color-border)] flex gap-3">
         <button
           onClick={() => setExpanded(!expanded)}
-          className="flex-1 px-4 py-2 text-blue-600 border border-blue-300 rounded hover:bg-blue-50 font-semibold transition"
+          className="flex-1 px-4 py-2 text-[var(--blue)] border border-[var(--blue)] rounded hover:opacity-80 font-semibold transition"
         >
           {expanded ? 'Ocultar detalles' : 'Ver detalles'}
         </button>
@@ -87,12 +87,12 @@ export default function FlightCard({ flight, onSelect, selectLabel }: FlightCard
           <button
             type="button"
             onClick={() => onSelect(flight)}
-            className="flex-1 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded font-semibold transition"
+            className="flex-1 px-4 py-2 bg-[var(--blue)] hover:opacity-90 text-white rounded font-semibold transition"
           >
             {selectLabel ?? 'Seleccionar'}
           </button>
         ) : (
-          <button className="flex-1 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded font-semibold transition">
+          <button className="flex-1 px-4 py-2 bg-[var(--blue)] hover:opacity-90 text-white rounded font-semibold transition">
             Seleccionar
           </button>
         )}
@@ -100,51 +100,51 @@ export default function FlightCard({ flight, onSelect, selectLabel }: FlightCard
 
       {/* Expanded Details */}
       {expanded && (
-        <div className="px-6 py-4 bg-white border-t border-gray-200">
+        <div className="px-6 py-4 bg-[var(--color-card-bg)] border-t border-[var(--color-border)]">
           <div className="space-y-4">
             <div>
-              <h4 className="font-semibold text-gray-900 mb-2">Información del Vuelo</h4>
-              <p className="text-sm text-gray-700">
-                <strong>Proveedor:</strong> {flight.provider_name}
+              <h4 className="font-semibold text-[var(--color-page-text-title)] mb-2">Información del Vuelo</h4>
+              <p className="text-sm text-[var(--color-page-text)]">
+                <strong>Proveedor:</strong> Duffel
               </p>
-              <p className="text-sm text-gray-700">
-                <strong>ID de Oferta:</strong> <code className="bg-gray-100 px-2 py-1 rounded text-xs">{flight.provider_offer_id}</code>
+              <p className="text-sm text-[var(--color-page-text)]">
+                <strong>ID de Oferta:</strong> <code className="bg-[var(--color-page-bg)] px-2 py-1 rounded text-xs">{flight.provider_offer_id}</code>
               </p>
             </div>
 
             <div>
-              <h4 className="font-semibold text-gray-900 mb-2">Desglose de Precio</h4>
-              <div className="bg-gray-50 p-3 rounded space-y-1 text-sm">
+              <h4 className="font-semibold text-[var(--color-page-text-title)] mb-2">Desglose de Precio</h4>
+              <div className="bg-[var(--color-page-bg)] p-3 rounded space-y-1 text-sm">
                 <p>
-                  <span className="text-gray-600">Precio original:</span>{' '}
-                  <span className="font-semibold">{formatPrice(flight.original_price, flight.original_currency)}</span>
+                  <span className="text-[var(--color-page-text)]">Precio original:</span>{' '}
+                  <span className="font-semibold text-[var(--color-page-text-title)]">{formatPrice(flight.original_price, flight.original_currency)}</span>
                 </p>
                 <p>
-                  <span className="text-gray-600">Tasa de cambio:</span>{' '}
-                  <span className="font-semibold">
+                  <span className="text-[var(--color-page-text)]">Tasa de cambio:</span>{' '}
+                  <span className="font-semibold text-[var(--color-page-text-title)]">
                     {(flight.total_price_mxn / flight.original_price).toFixed(2)} MXN
                   </span>
                 </p>
-                <p className="border-t border-gray-200 pt-2 mt-2">
-                  <span className="text-gray-600">Precio en MXN:</span>{' '}
-                  <span className="font-semibold text-blue-600">{formatPrice(flight.total_price_mxn)}</span>
+                <p className="border-t border-[var(--color-border)] pt-2 mt-2">
+                  <span className="text-[var(--color-page-text)]">Precio en MXN:</span>{' '}
+                  <span className="font-semibold text-[var(--blue)]">{formatPrice(flight.total_price_mxn)}</span>
                 </p>
               </div>
             </div>
 
             {flight.segments.length > 1 && (
               <div>
-                <h4 className="font-semibold text-gray-900 mb-2">Itinerario Completo</h4>
+                <h4 className="font-semibold text-[var(--color-page-text-title)] mb-2">Itinerario Completo</h4>
                 <div className="space-y-2">
                   {flight.segments.map((segment, idx) => (
-                    <div key={idx} className="bg-gray-50 p-3 rounded text-sm">
-                      <p className="font-semibold">
+                    <div key={idx} className="bg-[var(--color-page-bg)] p-3 rounded text-sm text-[var(--color-page-text)]">
+                      <p className="font-semibold text-[var(--color-page-text-title)]">
                         {segment.origin_airport_code} ({segment.origin_city}) → {segment.destination_airport_code} ({segment.destination_city})
                       </p>
-                      <p className="text-gray-600">
+                      <p>
                         Salida: {formatTime(segment.departure_at)}
                       </p>
-                      <p className="text-gray-600">
+                      <p>
                         Llegada: {formatTime(segment.arrival_at)}
                       </p>
                     </div>

--- a/src/components/flights/FlightReservationOptions.tsx
+++ b/src/components/flights/FlightReservationOptions.tsx
@@ -5,7 +5,7 @@
  *              into the reservation form.
  * Authors: Debug Studio (Diego de la Vega)
  * Last Modification made:
- * 12/05/2026 [Diego de la Vega] Added reservation-flow flight search integration.
+ * 12/05/2026 [Diego de la Vega] Added reservation-flow flight search integration and dark mode for some buttons.
  */
 
 import { useMemo } from 'react';
@@ -106,9 +106,9 @@ export default function FlightReservationOptions({
 
   if (!flightSearchQuery) {
     return (
-      <section className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 mb-8">
-        <h3 className="text-lg font-bold text-gray-900 mb-2">Opciones de vuelo</h3>
-        <p className="text-sm text-gray-600">
+      <section className="bg-[var(--color-card-bg)] rounded-lg shadow-sm border border-[var(--color-border)] p-6 mb-8">
+        <h3 className="text-lg font-bold text-[var(--color-page-text-title)] mb-2">Opciones de vuelo</h3>
+        <p className="text-sm text-[var(--color-page-text)]">
           No hay suficientes códigos IATA para buscar vuelos automáticamente.
         </p>
       </section>
@@ -118,16 +118,16 @@ export default function FlightReservationOptions({
   const data = searchResult.data as FlightSearchMultiSegmentResponse | undefined;
 
   return (
-    <section className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 mb-8">
+    <section className="bg-[var(--color-card-bg)] rounded-lg shadow-sm border border-[var(--color-border)] p-6 mb-8">
       <div className="flex flex-col gap-2 mb-6">
-        <h3 className="text-lg font-bold text-gray-900">Opciones de vuelo</h3>
-        <p className="text-sm text-gray-600">
+        <h3 className="text-lg font-bold text-[var(--color-page-text-title)]">Opciones de vuelo</h3>
+        <p className="text-sm text-[var(--color-page-text)]">
           Se muestran las mejores opciones por tramo para el itinerario cargado.
         </p>
       </div>
 
       {searchResult.isLoading && (
-        <div className="py-8 text-center text-gray-600">Buscando opciones en Duffel...</div>
+        <div className="py-8 text-center text-[var(--color-page-text)]">Buscando opciones en Duffel...</div>
       )}
 
       {searchResult.isError && (
@@ -144,11 +144,11 @@ export default function FlightReservationOptions({
 
             return (
               <div key={segment.segment_index} className="space-y-4">
-                <div className="flex flex-col gap-1 border-b border-gray-200 pb-3">
-                  <h4 className="text-base font-semibold text-gray-900">
+                <div className="flex flex-col gap-1 border-b border-[var(--color-border)] pb-3">
+                  <h4 className="text-base font-semibold text-[var(--color-page-text-title)]">
                     Tramo {segment.segment_index + 1}: {segment.route}
                   </h4>
-                  <p className="text-sm text-gray-600">
+                  <p className="text-sm text-[var(--color-page-text)]">
                     Fecha sugerida: {segmentDate ? formatDate(segmentDate) : 'Sin fecha'}
                   </p>
                 </div>
@@ -175,7 +175,7 @@ export default function FlightReservationOptions({
                     ))}
                   </div>
                 ) : (
-                  <div className="rounded bg-gray-50 border border-gray-200 p-4 text-sm text-gray-600">
+                  <div className="rounded bg-[var(--color-page-bg)] border border-[var(--color-border)] p-4 text-sm text-[var(--color-page-text)]">
                     No hay resultados para este tramo.
                   </div>
                 )}

--- a/src/components/travel-requests/TravelRequestForm.tsx
+++ b/src/components/travel-requests/TravelRequestForm.tsx
@@ -3,12 +3,9 @@
  * Description: Renders the travel request form for create/edit flows, validates inputs, and submits payloads to the API.
  * Authors: Original Monarca team
  * Last Modification made:
- * 24/02/2026 [Julio César Rodríguez Figueroa] Added detailed comments and documentation for clarity and maintainability.
- * 20/04/2026 [Sebastián Borjas] Fixed currency display on edit.
- * 20/04/2026 [Jin Sik Yoon] Improved error handling for better UX.
- * 20/04/2026 [Diego de la Vega] Enabled searchable origin/destination selectors with incremental filtering while typing.
- * 23/04/2026 [Santiago Coronado Hernández] Use PersistedForm hook to save form state in localStorage for better UX on accidental refreshes or navigation.
- * 04/05/2026 [Rebeca-Davila] Changed colors for dark mode
+ * 14/05/2026 [Diego de la Vega] Redesigned date model: each destination now only asks for departure_date;
+ *                               a single return_date field captures the trip end. arrival_date and stay_days
+ *                               are derived automatically at submit time. Validates sequential date order.
  */
 
 import { Button } from "../ui/Button";
@@ -23,10 +20,9 @@ import {
   Control,
   FieldErrors,
   UseFormRegister,
-  UseFormSetValue,
   Resolver,
 } from "react-hook-form";
-import { useForm, Controller, useFieldArray, useWatch } from "react-hook-form";
+import { useForm, Controller, useFieldArray } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { TFunction } from "i18next";
@@ -48,7 +44,6 @@ type Option = { id: number | string; name: string };
 // Static schema used only for type inference — messages don't affect types
 const _destinationSchema = z.object({
   id_destination: z.string().nullable(),
-  arrival_date: z.string().nonempty(),
   departure_date: z.string().nonempty(),
   stay_days: z.number().int(),
   is_hotel_required: z.boolean(),
@@ -70,6 +65,7 @@ const _formSchema = z.object({
     .transform((v) => Number(v))
     .refine((v) => v >= 0),
   currency: z.string().nonempty(),
+  return_date: z.string().nonempty(),
   requests_destinations: z.array(_destinationSchema).min(1),
 });
 
@@ -79,7 +75,6 @@ type SubmitValues = z.output<typeof _formSchema>;
 function makeFormSchema(t: TFunction) {
   const destinationSchema = z.object({
     id_destination: z.string().nullable(),
-    arrival_date: z.string().nonempty({ message: t('validation.selectArrivalDate') }),
     departure_date: z.string().nonempty({ message: t('validation.selectDepartureDate') }),
     stay_days: z.number().int(),
     is_hotel_required: z.boolean(),
@@ -105,6 +100,7 @@ function makeFormSchema(t: TFunction) {
         message: t('validation.nonNegativeAdvanceMoney'),
       }),
     currency: z.string().nonempty({ message: t('validation.selectCurrency') }),
+    return_date: z.string().nonempty({ message: t('validation.selectReturnDate') }),
     requests_destinations: z
       .array(destinationSchema)
       .min(1, t('validation.atLeastOneDestination')),
@@ -124,10 +120,14 @@ interface DestinationFieldsProps {
   destinationOptionsById: Map<string, { id: string | number; name: string }>;
   errors: FieldErrors<FormValues>["requests_destinations"];
   remove: (index: number) => void;
-  setValue: UseFormSetValue<FormValues>;
   isLoadingDestinations: boolean;
 }
 
+/**
+ * DestinationFields — renders inputs for a single destination leg.
+ * Only asks for departure_date (when you leave for this destination).
+ * arrival_date and stay_days are derived automatically at submit time.
+ */
 function DestinationFields({
   idx,
   control,
@@ -136,30 +136,9 @@ function DestinationFields({
   destinationOptionsById,
   errors,
   remove,
-  setValue,
   isLoadingDestinations,
 }: DestinationFieldsProps) {
   const { t } = useTranslation();
-
-  const arrivalDate = useWatch({
-    control,
-    name: `requests_destinations.${idx}.arrival_date`,
-  });
-
-  const departureDate = useWatch({
-    control,
-    name: `requests_destinations.${idx}.departure_date`,
-  });
-
-  const stayDays =
-    arrivalDate && departureDate
-      ? dayjs(arrivalDate).diff(dayjs(departureDate), "day")
-      : 0;
-
-  useEffect(() => {
-    setValue(`requests_destinations.${idx}.stay_days`, stayDays);
-  }, [arrivalDate, departureDate, idx, setValue, stayDays]);
-
   const destinationErrors = errors?.[idx];
 
   return (
@@ -236,43 +215,6 @@ function DestinationFields({
             )}
           />
           <FieldError msg={destinationErrors?.departure_date?.message} />
-        </div>
-
-        <div>
-          <label
-            htmlFor={`arrival-${idx}`}
-            className="block mb-2 text-sm font-medium text-[var(--color-page-text)]"
-          >
-            {t('form.arrivalDate')}
-          </label>
-          <Controller
-            control={control}
-            name={`requests_destinations.${idx}.arrival_date`}
-            render={({ field }) => (
-              <Input
-                id={`arrival-${idx}`}
-                type="date"
-                value={field.value ? dayjs(field.value).format("YYYY-MM-DD") : ""}
-                onChange={e => field.onChange(e.target.value)}
-              />
-            )}
-          />
-          <FieldError msg={destinationErrors?.arrival_date?.message} />
-        </div>
-
-        <div>
-          <label
-            htmlFor={`stay-days-${idx}`}
-            className="block mb-2 text-sm font-medium text-[var(--color-page-text)]"
-          >
-            {t('form.stayDays')}
-          </label>
-          <Input
-            id={`stay-days-${idx}`}
-            type="number"
-            value={stayDays}
-            readOnly
-          />
         </div>
 
         <div>
@@ -363,10 +305,17 @@ function TravelRequestForm({ initialData, requestId }: TravelRequestFormProps) {
     }
 
     const parsedAdvanceMoney = Number(initialData.advance_money);
+    const dests = initialData.requests_destinations ?? [];
+    // The return date is stored as arrival_date of the last destination
+    const lastDest = dests[dests.length - 1];
+    const returnDate = lastDest?.arrival_date
+      ? dayjs(lastDest.arrival_date).format("YYYY-MM-DD")
+      : "";
 
     return {
       ...initialData,
       id_origin_city: initialData.id_origin_city ?? null,
+      return_date: returnDate,
       advance_money:
         initialData.advance_money !== undefined &&
         initialData.advance_money !== null
@@ -374,8 +323,12 @@ function TravelRequestForm({ initialData, requestId }: TravelRequestFormProps) {
             ? parsedAdvanceMoney.toFixed(2)
             : "0.00"
           : "0.00",
-      requests_destinations: initialData.requests_destinations.map((destination) => ({
-        ...destination,
+      requests_destinations: dests.map((destination) => ({
+        id_destination: destination.id_destination,
+        departure_date: destination.departure_date ?? "",
+        stay_days: destination.stay_days ?? 1,
+        is_hotel_required: destination.is_hotel_required,
+        is_plane_required: destination.is_plane_required,
         details: destination.details ?? "",
       })),
     };
@@ -387,7 +340,6 @@ function TravelRequestForm({ initialData, requestId }: TravelRequestFormProps) {
     handleSubmit,
     formState: { errors },
     reset,
-    setValue,
     trigger,
   } = useForm<FormValues, unknown, SubmitValues>({
     resolver,
@@ -399,10 +351,10 @@ function TravelRequestForm({ initialData, requestId }: TravelRequestFormProps) {
       advance_money: "0.00",
       currency: "",
       requirements: "",
+      return_date: "",
       requests_destinations: [
         {
           id_destination: null,
-          arrival_date: "",
           departure_date: "",
           stay_days: 1,
           is_hotel_required: true,
@@ -441,30 +393,51 @@ function TravelRequestForm({ initialData, requestId }: TravelRequestFormProps) {
       return;
     }
 
-    const hasInvalidStay = data.requests_destinations.some((d) => {
-      const diff = dayjs(d.arrival_date).diff(dayjs(d.departure_date), "day");
-      return diff <= 0;
-    });
+    // Validate sequential departure dates
+    for (let i = 1; i < data.requests_destinations.length; i++) {
+      const prevDest = data.requests_destinations[i - 1];
+      const currDest = data.requests_destinations[i];
+      if (!prevDest || !currDest) continue;
+      const prev = dayjs(prevDest.departure_date);
+      const curr = dayjs(currDest.departure_date);
+      if (!curr.isAfter(prev)) {
+        toast.error(t('toast.departureDateOrder', { num: i + 1 }), {
+          position: "top-right",
+          autoClose: 4000,
+        });
+        return;
+      }
+    }
 
-    if (hasInvalidStay) {
-      toast.error(t('toast.positiveStayDays'), {
+    // Validate return date is after last departure
+    const lastDest = data.requests_destinations[data.requests_destinations.length - 1];
+    const lastDeparture = dayjs(lastDest?.departure_date ?? "");
+    if (!dayjs(data.return_date).isAfter(lastDeparture)) {
+      toast.error(t('toast.returnDateAfterLast'), {
         position: "top-right",
-        autoClose: 3000,
+        autoClose: 4000,
       });
       return;
     }
 
+    // Derive arrival_date and stay_days for each destination
     const requests_destinations = data.requests_destinations.map(
       (d, idx, arr) => {
         if (!d.id_destination) {
           throw new Error(t('form.destinationPlaceholder'));
         }
+        // arrival = next destination's departure, or return_date for the last leg
+        const nextDest = arr[idx + 1];
+        const arrivalIso = idx < arr.length - 1
+          ? dayjs(nextDest?.departure_date).toISOString()
+          : dayjs(data.return_date).toISOString();
+        const stayDays = dayjs(arrivalIso).diff(dayjs(d.departure_date), "day");
 
         return {
           id_destination: d.id_destination,
           destination_order: idx + 1,
-          stay_days: d.stay_days,
-          arrival_date: dayjs(d.arrival_date).toISOString(),
+          stay_days: stayDays,
+          arrival_date: arrivalIso,
           departure_date: dayjs(d.departure_date).toISOString(),
           is_hotel_required: d.is_hotel_required,
           is_plane_required: d.is_plane_required,
@@ -711,10 +684,36 @@ function TravelRequestForm({ initialData, requestId }: TravelRequestFormProps) {
                   destinationOptionsById={destinationOptionsById}
                   errors={errors.requests_destinations}
                   remove={remove}
-                  setValue={setValue}
                   isLoadingDestinations={isLoadingDestinations}
                 />
               ))}
+
+              {/* Single return date shared across the whole trip */}
+              <div className="rounded-md p-4 mb-6 bg-[var(--color-page-bg)] shadow-sm">
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div>
+                    <label
+                      htmlFor="return_date"
+                      className="block mb-2 text-sm font-medium text-[var(--color-page-text)]"
+                    >
+                      {t('form.returnDate')}
+                    </label>
+                    <Controller
+                      control={control}
+                      name="return_date"
+                      render={({ field }) => (
+                        <Input
+                          id="return_date"
+                          type="date"
+                          value={field.value ? dayjs(field.value).format("YYYY-MM-DD") : ""}
+                          onChange={e => field.onChange(e.target.value)}
+                        />
+                      )}
+                    />
+                    <FieldError msg={(errors as any).return_date?.message} />
+                  </div>
+                </div>
+              </div>
             </div>
             <Button
               id="new_destination"
@@ -722,7 +721,6 @@ function TravelRequestForm({ initialData, requestId }: TravelRequestFormProps) {
               onClick={() =>
                 append({
                   id_destination: null,
-                  arrival_date: "",
                   departure_date: "",
                   stay_days: 1,
                   is_hotel_required: false,

--- a/src/hooks/auth/authContext.tsx
+++ b/src/hooks/auth/authContext.tsx
@@ -3,7 +3,7 @@
  * Description: Authentication and authorization context for the frontend. Provides auth state (user info + permissions), login session validation via profile endpoint, logout handling, and route protection components (basic auth + permission-based guards).
  * Authors: Original Moncarca team
  * Last Modification made:
- * 05/05/2026 [Santiago Coronado Hernández] Added company id to auth state and included it in the profile fetch logic to support company-scoped features and permissions in the frontend.
+ * 14/05/2026 [Diego de la Vega] Integrated flight search and reservation flow updates.
  */
 
 import React, { createContext, useContext, ReactNode, useEffect } from "react";
@@ -209,13 +209,29 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
  * - Layout is applied to provide consistent UI shell (navbar/sidebar/etc.).
  */
 export const ProtectedRoute: React.FC = () => {
-  return (
-    <AuthProvider>
+  const AuthGate: React.FC = () => {
+    const { authState, loadingProfile } = useAuth();
+
+    if (loadingProfile) {
+      return null;
+    }
+
+    if (!authState.isAuthenticated) {
+      return <Navigate to="/" replace />;
+    }
+
+    return (
       <AppProvider>
         <Layout>
           <Outlet />
         </Layout>
       </AppProvider>
+    );
+  };
+
+  return (
+    <AuthProvider>
+      <AuthGate />
     </AuthProvider>
   );
 };

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -155,7 +155,7 @@
     "destinationNum": "Destination #{{num}}",
     "destinationPlaceholder": "Search a destination",
     "departureDate": "Departure date",
-    "arrivalDate": "Arrival date",
+    "returnDate": "Return date",
     "stayDays": "Stay days",
     "needsFlight": "Needs flight?",
     "needsHotel": "Needs hotel?",
@@ -186,7 +186,7 @@
     "writeMotive": "Please write a motive",
     "atLeastOneDestination": "Add at least one destination",
     "selectDepartureDate": "Select a departure date",
-    "selectArrivalDate": "Select an arrival date",
+    "selectReturnDate": "Select a return date",
     "addDetails": "Add details",
     "advanceMoneyRequired": "Advance is required",
     "nonNegativeAdvanceMoney": "Advance cannot be negative",
@@ -211,7 +211,8 @@
     "errorCreating": "Error creating request",
     "errorUpdating": "Error updating request",
     "selectOrigin": "Select an origin city",
-    "positiveStayDays": "Stay days must be positive"
+    "departureDateOrder": "Departure date for destination #{{num}} must be after the previous destination's",
+    "returnDateAfterLast": "Return date must be after the last departure date"
   },
   "requestInfo": {
     "title": "Request information",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -155,7 +155,7 @@
     "destinationNum": "Destino #{{num}}",
     "destinationPlaceholder": "Busca un destino",
     "departureDate": "Fecha de salida",
-    "arrivalDate": "Fecha de llegada",
+    "returnDate": "Fecha de regreso",
     "stayDays": "Días de estadía",
     "needsFlight": "¿Necesita vuelo?",
     "needsHotel": "¿Necesita hotel?",
@@ -186,7 +186,7 @@
     "writeMotive": "Por favor escribe un motivo",
     "atLeastOneDestination": "Agrega al menos un destino",
     "selectDepartureDate": "Selecciona una fecha de salida",
-    "selectArrivalDate": "Selecciona una fecha de llegada",
+    "selectReturnDate": "Selecciona una fecha de regreso",
     "addDetails": "Agrega detalles",
     "advanceMoneyRequired": "El anticipo es requerido",
     "nonNegativeAdvanceMoney": "El anticipo no puede ser negativo",
@@ -211,7 +211,8 @@
     "errorCreating": "Error al crear la solicitud",
     "errorUpdating": "Error al actualizar la solicitud",
     "selectOrigin": "Selecciona una ciudad de origen",
-    "positiveStayDays": "Los días de estadía deben ser positivos"
+    "departureDateOrder": "La fecha de salida del destino #{{num}} debe ser posterior a la del destino anterior",
+    "returnDateAfterLast": "La fecha de regreso debe ser posterior a la última fecha de salida"
   },
   "requestInfo": {
     "title": "Información de la solicitud",

--- a/src/pages/Historial/Historial.tsx
+++ b/src/pages/Historial/Historial.tsx
@@ -4,8 +4,7 @@
  * It provides a customizable history page with travel records and related actions.
  * Authors: Original Moncarca team
  * Last Modification made:
- * 13/05/2026 [Julio Rodriguez] Tied history filters to their endpoint instead of user permissions to prevent
- *                              null crash on travel_agency and incorrect filtering for multi-role users.
+ * 14/05/2026 [Diego de la Vega] Now travel agents see all requests except those in early stages
  */
 
 import Table from "../../components/Refunds/Table";
@@ -118,7 +117,10 @@ export const Historial = () => {
         }
         if (endpoint === "/requests/all") {
           const travelAgentsIds = response.flatMap((request: any) => (request.travel_agency?.users ?? []).map((user: any) => user.id));
+          // Travel agents see all requests except those in early stages (before they make reservations)
+          // Status shows only after reservations are completed (In Progress onwards)
           response = response.filter((record: any) => !["Pending Review", "Denied", "Cancelled", "Changes Needed", "Pending Reservations"].includes(record.status) && travelAgentsIds.includes(authState.userId));
+
         }
         if (endpoint === "/requests/to-approve-SOI") {
           response = response.filter((record: any) => ["Pending Accounting Approval"].includes(record.status) && record.id_SOI === authState.userId);

--- a/src/pages/RequestInfo.tsx
+++ b/src/pages/RequestInfo.tsx
@@ -3,7 +3,7 @@
  * Description: Displays travel request details, destination/reservation data, and role-based request actions.
  * Authors: Original Moncarca team
  * Last Modification made:
- * 04/05/2026 [Rebeca-Davila] Changed colors for dark mode
+ * 14/05/2026 [Diego de la Vega] Update destinations display to show origin-to-destination flow and synthesize return legs. Added dark mode for some buttons.
  */
 
 import React, { useState, useEffect } from 'react';
@@ -160,9 +160,48 @@ const RequestInfo: React.FC = () => {
         const reservations = (response.requests_destinations || [])
           .map((dest: any) => dest.reservations)
           .flat();
-        console.log(response);
+          
+        const sortedDests = [...(response.requests_destinations || [])].sort(
+          (a: any, b: any) => a.destination_order - b.destination_order
+        );
+
+        const mappedDests = sortedDests.map((destination: any, idx: number) => {
+          const prevDest = idx > 0 ? sortedDests[idx - 1] : null;
+          const originCity = prevDest
+            ? prevDest.destination?.city || prevDest.destination?.iata_code || t('historial.noDestination')
+            : response.destination?.city || response.destination?.iata_code || t('historial.noDestination');
+            
+          return {
+            ...destination,
+            origin_city: originCity,
+            destination_city: destination.destination?.city || destination.destination?.iata_code || t('historial.noDestination'),
+          };
+        });
+
+        const lastReal = mappedDests[mappedDests.length - 1];
+        if (lastReal?.arrival_date) {
+          const returnOriginCity = lastReal.destination_city;
+          const returnDestCity = response.destination?.city || response.destination?.iata_code || t('historial.noDestination');
+          
+          mappedDests.push({
+            id: lastReal.id + ':return',
+            destination_order: mappedDests.length + 1,
+            is_synthetic_return: true,
+            origin_city: returnOriginCity,
+            destination_city: returnDestCity,
+            departure_date: lastReal.arrival_date,
+            arrival_date: "",
+            is_hotel_required: false,
+            is_plane_required: true,
+            stay_days: 0,
+            details: "",
+            provider_support_status: lastReal.provider_support_status
+          });
+        }
+
         setData({
           ...response,
+          requests_destinations: mappedDests,
           effective_advance_money: effectiveAdvanceMoney,
           reservations: reservations,
           createdAt: formatDate(response.createdAt),
@@ -268,7 +307,18 @@ const RequestInfo: React.FC = () => {
     const fetchAgencies = async () => {
       try {
         const response = await getRequest('/travel-agencies');
-        setAgencies(response);
+        // Deduplicate agencies by normalized name (case-insensitive) so duplicates like
+        // multiple 'Duffel' entries are shown only once in the selector.
+        const seen = new Set<string>();
+        const deduped: any[] = [];
+        for (const ag of response || []) {
+          const key = (ag?.name || '').toString().trim().toLowerCase();
+          if (!seen.has(key)) {
+            seen.add(key);
+            deduped.push(ag);
+          }
+        }
+        setAgencies(deduped);
       } catch (error) {
         console.error('Error fetching agencies data:', error);
       }
@@ -525,25 +575,7 @@ const RequestInfo: React.FC = () => {
                       id={`destination-${index}`}
                       type="text"
                       readOnly
-                      value={
-                        dest.destination?.city ||
-                        dest.destination?.iata_code ||
-                        t('historial.noDestination')
-                      }
-                      className="w-full bg-[var(--color-card-bg)] text-[var(--color-page-text)] rounded-lg px-3 py-2 border border-[var(--color-border)]"
-                    />
-                  </div>
-                  <div>
-                    <label
-                      className="block text-xs font-semibold text-gray-500 mb-1"
-                    >
-                      {t('requestInfo.arrivalDate')}
-                    </label>
-                    <input
-                      id={`arrival-${index}`}
-                      type="text"
-                      readOnly
-                      value={dest.arrival_date ? formatDate(dest.arrival_date) : t('historial.noDate')}
+                      value={`${dest.origin_city} -> ${dest.destination_city}`}
                       className="w-full bg-[var(--color-card-bg)] text-[var(--color-page-text)] rounded-lg px-3 py-2 border border-[var(--color-border)]"
                     />
                   </div>
@@ -664,13 +696,13 @@ const RequestInfo: React.FC = () => {
                         </SwiperSlide>
                       ))}
                     </Swiper>
-                    <div className="flex space-x-4 absolute z-10 top-2 right-4 bg-white">
+                    <div className="flex space-x-4 absolute z-10 top-2 right-4 bg-[var(--color-page-bg)]">
                       <button
                         ref={prevRefRes}
                         disabled={currentIndexRes === 0}
-                        className={`px-4 py-2 rounded-md hover:cursor-pointer ${currentIndexRes === 0
-                            ? "bg-gray-200 text-gray-500 cursor-not-allowed"
-                            : "bg-gray-300 text-gray-700 hover:bg-gray-400"
+                        className={`px-4 py-2 rounded-md border border-[var(--color-border)] ${currentIndexRes === 0
+                            ? "bg-[var(--color-card-bg)] text-[var(--color-page-text)] opacity-50 cursor-not-allowed"
+                            : "bg-[var(--color-card-bg)] text-[var(--color-page-text-title)] hover:bg-[var(--color-page-bg)]"
                           }`}
                       >
                         {t('requestInfo.previous')}
@@ -678,9 +710,9 @@ const RequestInfo: React.FC = () => {
                       <button
                         disabled={currentIndexRes === ((data?.reservations?.length ?? 0) - 1)}
                         ref={nextRefRes}
-                        className={`px-4 py-2 rounded-md hover:cursor-pointer ${currentIndexRes === (data?.reservations?.length ?? 0) - 1
-                            ? "bg-gray-200 text-gray-500 cursor-not-allowed"
-                            : "bg-gray-300 text-gray-700 hover:bg-gray-400"
+                        className={`px-4 py-2 rounded-md border border-[var(--color-border)] ${currentIndexRes === (data?.reservations?.length ?? 0) - 1
+                            ? "bg-[var(--color-card-bg)] text-[var(--color-page-text)] opacity-50 cursor-not-allowed"
+                            : "bg-[var(--color-card-bg)] text-[var(--color-page-text-title)] hover:bg-[var(--color-page-bg)]"
                           }`}
                       >
                         {t('requestInfo.next')}
@@ -744,13 +776,13 @@ const RequestInfo: React.FC = () => {
                         </SwiperSlide>
                       ))}
                     </Swiper>
-                    <div className="flex space-x-4 absolute z-10 top-2 right-4 bg-white">
+                    <div className="flex space-x-4 absolute z-10 top-2 right-4 bg-[var(--color-page-bg)]">
                       <button
                         ref={prevRef}
                         disabled={currentIndex === 0}
-                        className={`px-4 py-2 rounded-md hover:cursor-pointer ${currentIndex === 0
-                            ? "bg-gray-200 text-gray-500 cursor-not-allowed"
-                            : "bg-gray-300 text-gray-700 hover:bg-gray-400"
+                        className={`px-4 py-2 rounded-md border border-[var(--color-border)] ${currentIndex === 0
+                            ? "bg-[var(--color-card-bg)] text-[var(--color-page-text)] opacity-50 cursor-not-allowed"
+                            : "bg-[var(--color-card-bg)] text-[var(--color-page-text-title)] hover:bg-[var(--color-page-bg)]"
                           }`}
                       >
                         Anterior
@@ -758,9 +790,9 @@ const RequestInfo: React.FC = () => {
                       <button
                         disabled={currentIndex === ((data?.vouchers?.length ?? 0) - 1)}
                         ref={nextRef}
-                        className={`px-4 py-2 rounded-md hover:cursor-pointer ${currentIndex === (data?.vouchers?.length ?? 0) - 1
-                            ? "bg-gray-200 text-gray-500 cursor-not-allowed"
-                            : "bg-gray-300 text-gray-700 hover:bg-gray-400"
+                        className={`px-4 py-2 rounded-md border border-[var(--color-border)] ${currentIndex === (data?.vouchers?.length ?? 0) - 1
+                            ? "bg-[var(--color-card-bg)] text-[var(--color-page-text)] opacity-50 cursor-not-allowed"
+                            : "bg-[var(--color-card-bg)] text-[var(--color-page-text-title)] hover:bg-[var(--color-page-bg)]"
                           }`}
                       >
                         Siguiente
@@ -845,7 +877,7 @@ const RequestInfo: React.FC = () => {
                 <input
                   type="text"
                   readOnly
-                  value={agencies?.find(agency => agency.id === data.id_travel_agency)?.name}
+                  value={agencies?.find(agency => agency.id === data.id_travel_agency)?.name ?? ''}
                   className="w-full bg-[var(--color-card-bg)] text-[var(--color-page-text)] border border-[var(--color-border)] rounded-lg px-3 py-2"
                 />
               )}

--- a/src/pages/Reservations/Reservations.tsx
+++ b/src/pages/Reservations/Reservations.tsx
@@ -121,16 +121,24 @@ export const Reservations = () => {
       try {
         // Simulate an API call to fetch data
         const response = await getRequest(`/requests/${requestId}`);
-        setRequest({
-          ...response,
-          requests_destinations: (response.requests_destinations || []).map((destination: any) => ({
+        const sortedDests = [...(response.requests_destinations || [])].sort(
+          (a: any, b: any) => a.destination_order - b.destination_order
+        );
+
+        const mappedDests = sortedDests.map((destination: any, idx: number) => {
+          // Origin of leg #N = destination city of leg #(N-1), or the request's origin city for the first leg
+          const prevDest = idx > 0 ? sortedDests[idx - 1] : null;
+          const originCity = prevDest
+            ? prevDest.destination?.city || prevDest.destination?.iata_code || t('reservations.unavailable')
+            : response.destination?.city || response.destination?.iata_code || t('reservations.unavailable');
+          const originCountry = prevDest
+            ? prevDest.destination?.country || ""
+            : response.destination?.country || "";
+          return {
             ...destination,
-            origin: `${response.destination?.city || response.destination?.iata_code || t('reservations.unavailable')}${response.destination?.country ? `, ${response.destination.country}` : ""}`,
-            origin_city:
-              response.destination?.city ||
-              response.destination?.iata_code ||
-              t('reservations.unavailable'),
-            origin_country: response.destination?.country || "",
+            origin: `${originCity}${originCountry ? `, ${originCountry}` : ""}`,
+            origin_city: originCity,
+            origin_country: originCountry,
             destination_full: `${destination.destination?.city || destination.destination?.iata_code || t('reservations.unavailable')}${destination.destination?.country ? `, ${destination.destination.country}` : ""}`,
             destination_city:
               destination.destination?.city ||
@@ -145,7 +153,51 @@ export const Reservations = () => {
             plane_required: destination.is_plane_required ? t('reservations.yes') : t('reservations.no'),
             stay_days: destination.stay_days,
             details: destination.details,
-          })),
+          };
+        });
+
+        // Synthesize return leg if last destination has a return date
+        const lastReal = mappedDests[mappedDests.length - 1];
+        if (lastReal?.arrival_date_raw) {
+          const returnOriginCity = lastReal.destination_city;
+          const returnOriginCountry = lastReal.destination_country;
+          const returnDestCity = response.destination?.city || response.destination?.iata_code || t('reservations.unavailable');
+          const returnDestCountry = response.destination?.country || "";
+          mappedDests.push({
+            // Synthetic entry — uses real last-destination ID suffixed with ':return'
+            // so we can strip the suffix when submitting to the API
+            id: lastReal.id + ':return',
+            destination_order: mappedDests.length + 1,
+            is_synthetic_return: true,
+            // origin = last real destination's city
+            origin: `${returnOriginCity}${returnOriginCountry ? `, ${returnOriginCountry}` : ""}`,
+            origin_city: returnOriginCity,
+            origin_country: returnOriginCountry,
+            // destination = request origin city (trip starts and ends here)
+            destination: {
+              iata_code: response.destination?.iata_code,
+              city: response.destination?.city,
+              country: response.destination?.country,
+            },
+            destination_full: `${returnDestCity}${returnDestCountry ? `, ${returnDestCountry}` : ""}`,
+            destination_city: returnDestCity,
+            destination_country: returnDestCountry,
+            departure_date: formatDate(lastReal.arrival_date_raw),
+            departure_date_raw: lastReal.arrival_date_raw,
+            arrival_date: "",
+            arrival_date_raw: undefined,
+            is_hotel_required: false,
+            is_plane_required: true,
+            hotel_required: t('reservations.no'),
+            plane_required: t('reservations.yes'),
+            stay_days: 0,
+            details: "",
+          });
+        }
+
+        setRequest({
+          ...response,
+          requests_destinations: mappedDests,
         });
       } catch (error) {
         console.error("Error fetching data:", error);
@@ -306,6 +358,7 @@ export const Reservations = () => {
         plane_comments: `Proveedor: ${flight.provider_name}. Oferta: ${flight.provider_offer_id}. Precio original: ${flight.original_price} ${flight.original_currency}.`,
         plane_price: Number(flight.total_price_mxn || 0).toFixed(2),
         plane_link: flight.provider_offer_id,
+        plane_price_locked: true,  // lock price to prevent accidental edits
       },
     }));
 
@@ -333,20 +386,30 @@ export const Reservations = () => {
     // Format the formData to match the API requirements
     const formattedData = {
       reservations: Object.entries(formData).flatMap(([key, value]) => {
+        // Synthetic return leg: strip ':return' suffix to get the real destination ID
+        const realDestId = key.endsWith(':return') ? key.slice(0, -7) : key;
+
         const hotelReservation = value.hotel_title && {
           title: value.hotel_title,
           comments: value.hotel_comments,
           price: parseFloat(value.hotel_price),
           file: value.hotel_file,
-          id_request_destination: key,
+          id_request_destination: realDestId,
         };
+
+        // Detect whether the flight link comes from Duffel (offer IDs start with 'off_')
+        const isDuffelFlight = typeof value.plane_link === 'string' && value.plane_link.startsWith('off_');
         const planeReservation = value.plane_title && {
           title: value.plane_title,
           comments: value.plane_comments,
           price: parseFloat(value.plane_price),
           link: value.plane_link,
           file: value.plane_file,
-          id_request_destination: key,
+          id_request_destination: realDestId,
+          ...(isDuffelFlight && {
+            provider_id: 'duffel',
+            provider_name: 'Duffel',
+          }),
         };
         return [hotelReservation, planeReservation].filter(Boolean);
       }),
@@ -388,16 +451,24 @@ export const Reservations = () => {
     try {
       await Promise.all(
         formattedData.reservations.map(async (reservation) => {
-          const formData = new FormData();
-          formData.append("title", reservation.title);
-          formData.append("comments", reservation.comments);
-          formData.append("price", reservation.price);
+          const reservationFormData = new FormData();
+          reservationFormData.append("title", reservation.title);
+          reservationFormData.append("comments", reservation.comments);
+          reservationFormData.append("price", reservation.price);
           if (reservation.link) {
-            formData.append("link", reservation.link);
+            reservationFormData.append("link", reservation.link);
           }
-          formData.append("file", reservation.file);
-          formData.append("id_request_destination", reservation.id_request_destination);
-          await postRequest("/reservations", formData);
+          if (reservation.provider_id) {
+            reservationFormData.append("provider_id", reservation.provider_id);
+          }
+          if (reservation.provider_name) {
+            reservationFormData.append("provider_name", reservation.provider_name);
+          }
+          if (reservation.file) {
+            reservationFormData.append("file", reservation.file);
+          }
+          reservationFormData.append("id_request_destination", reservation.id_request_destination);
+          await postRequest("/reservations", reservationFormData);
         })
       );
       toast.success(t('reservations.success'));
@@ -441,7 +512,9 @@ export const Reservations = () => {
             onSubmit={handleSubmit}
           >
             <div className="">
-              {request?.requests_destinations?.map((destination: any) => (
+              {[...(request?.requests_destinations || [])]
+                .sort((a: any, b: any) => a.destination_order - b.destination_order)
+                .map((destination: any) => (
                 <div
                   key={destination.id}
                   className="rounded-md p-4 mb-6 space-y-4 bg-[var(--color-page-bg)] shadow-sm"
@@ -621,24 +694,33 @@ export const Reservations = () => {
                           </label>
                           <div className="flex items-center gap-2">
                             <input
-                              className="w-full bg-[var(--color-card-bg)] text-[var(--color-page-text)] border-[var(--color-border)] rounded-lg px-3 py-2"
+                              className={`w-full rounded-lg border px-3 py-2 ${
+                                formData[destination.id]?.plane_price_locked
+                                  ? "bg-gray-100 border-gray-200 text-gray-500 cursor-not-allowed opacity-75"
+                                  : "bg-[var(--color-card-bg)] text-[var(--color-page-text)] border-[var(--color-border)]"
+                              }`}
                               placeholder={t('reservations.flightPricePlaceholder')}
                               value={formData[destination.id]?.plane_price ?? "0.00"}
+                              readOnly={!!formData[destination.id]?.plane_price_locked}
                               onChange={(e) => {
+                                if (formData[destination.id]?.plane_price_locked) return;
                                 const value = e.target.value;
-
                                 if (value === "" || /^\d*\.?\d{0,2}$/.test(value)) {
                                   handleChange(e, destination.id);
                                 }
                               }}
-                              onWheel={(e) => handlePriceWheel(e, destination.id)}
+                              onWheel={(e) => {
+                                if (!formData[destination.id]?.plane_price_locked) handlePriceWheel(e, destination.id);
+                              }}
                               onMouseEnter={() => setPageScroll(false)}
                               onMouseLeave={() => setPageScroll(true)}
                               onFocus={() => setPageScroll(false)}
                               onBlur={(e) => {
-                                const value = e.target.value.trim();
-                                e.target.value = value === "" ? "0.00" : Number(value).toFixed(2);
-                                handleChange(e, destination.id);
+                                if (!formData[destination.id]?.plane_price_locked) {
+                                  const value = e.target.value.trim();
+                                  e.target.value = value === "" ? "0.00" : Number(value).toFixed(2);
+                                  handleChange(e, destination.id);
+                                }
                                 setPageScroll(true);
                               }}
                               onKeyDown={(e) => {
@@ -653,6 +735,26 @@ export const Reservations = () => {
                             />
                             <span className="text-sm font-semibold text-gray-600 whitespace-nowrap">MXN</span>
                           </div>
+                          {formData[destination.id]?.plane_price_locked && (
+                            <p className="text-xs text-gray-500 mt-1">
+                              Precio fijado por Duffel.{" "}
+                              <button
+                                type="button"
+                                className="text-blue-600 underline"
+                                onClick={() =>
+                                  setFormData((prev) => ({
+                                    ...prev,
+                                    [destination.id]: {
+                                      ...prev[destination.id],
+                                      plane_price_locked: false,
+                                    },
+                                  }))
+                                }
+                              >
+                                Editar manualmente
+                              </button>
+                            </p>
+                          )}
                         </div>
 
                         <div>

--- a/src/utils/apiService.tsx
+++ b/src/utils/apiService.tsx
@@ -3,7 +3,7 @@
  * Description: Centralized Axios configuration and HTTP utility functions for handling API requests (GET, POST, PUT, PATCH, DELETE) with global error interception.
  * Authors: Original Moncarca team
  * Last Modification made:
- * 04/05/2026 [Santiago Coronado Hernández] Added enhanced error logging in the response interceptor to provide more insights into API errors, including specific handling for file size validation errors and unauthorized access (401) for potential token refresh logic.
+ * 14/05/2026 [Diego de la Vega] Added flight search API endpoints and handlers.
  */
 
 import axios, { AxiosRequestConfig } from "axios";
@@ -34,18 +34,32 @@ api.interceptors.response.use(
   (response) => response,
   (error) => {
     if (error.response) {
+      const errorCode = error.response.data?.code;
       console.error(
         "API ERROR FULL:",
         JSON.stringify(error.response?.data, null, 2)
       );
       // Log file size errors specifically
+      const message = Array.isArray(error.response.data?.message)
+        ? error.response.data.message.join(', ')
+        : error.response.data?.message;
       if (error.response.status === 413 || 
           (error.response.status === 400 && 
-           error.response.data?.message?.toLowerCase().includes("size"))) {
-        console.error("File size validation error:", error.response.data?.message);
+           typeof message === 'string' && message.toLowerCase().includes("size"))) {
+        console.error("File size validation error:", message);
       }
       if (error.response.status === 401) {
         // Token refresh logic or redirect to login could be implemented here
+      }
+
+      // If auth context is missing/invalid, send user back to login immediately.
+      if (
+        errorCode === "AUTH_MISSING_TOKEN" ||
+        errorCode === "AUTH_INVALID_TOKEN"
+      ) {
+        if (window.location.pathname !== "/") {
+          window.location.href = "/";
+        }
       }
     } else if (error.request) {
       console.error("se recibió respuesta de la API:", error.request);


### PR DESCRIPTION
feat(flights): integrate Duffel search and sequential dates

## What
- Redesigned the date model to use sequential `departure_date`s and a single global `return_date`.
- Integrated Duffel flight search into the reservations view, auto-filling and locking selected prices.
- Added visual synthetic return legs to the request history views.
- Fixed travel agent history filters and resolved Dark Mode UI merge conflicts.

The previous manual date model didn't align with real flight itineraries. Moving to a sequential origin-destination flow enables the Duffel API integration, streamlining the travel agent workflow and preventing manual data entry errors.

## How to test (optional)
1. Create a travel request and verify the new sequential date flow.
2. Log in as a Travel Agent, open the request, and test the Duffel flight options.
3. Select a flight and verify that the price input locks.
4. Toggle Dark Mode to ensure the new flight cards and PDF buttons display correctly.