### PR TITLE
fix(frontend): grabbed PR 93 and changed to not have conflict with present permission logic and frontend components

### DIFF
--- a/src/pages/Historial/Historial.tsx
+++ b/src/pages/Historial/Historial.tsx
@@ -4,7 +4,7 @@
  * It provides a customizable history page with travel records and related actions.
  * Authors: Original Moncarca team
  * Last Modification made:
- * 14/05/2026 [Diego de la Vega] Now travel agents see all requests except those in early stages
+ * 17/05/2026 [Santiago Coronado Hernández and Juan Pablo Narchi] Make it so that travel agents can see all reserved requests.
  */
 
 import Table from "../../components/Refunds/Table";
@@ -104,7 +104,10 @@ export const Historial = () => {
     const fetchTravelRecords = async () => {
       try {
         const endpoint =
-          authState.userPermissions.includes("view_own_requests" as Permission)
+          authState.userPermissions.includes("view_assigned_requests_readonly" as Permission) &&
+          authState.userPermissions.includes("submit_reservations" as Permission)
+            ? "/requests/reserved-history"
+            : authState.userPermissions.includes("view_own_requests" as Permission)
             ? "/requests/user"
             : authState.userPermissions.includes("check_budgets" as Permission)
             ? "/requests/to-approve-SOI"
@@ -115,12 +118,8 @@ export const Historial = () => {
         if (endpoint === "/requests/approved-history") {
           response = response.filter((record: any) => !["Pending Review", "Denied", "Cancelled"].includes(record.status) && record.id_admin === authState.userId);
         }
-        if (endpoint === "/requests/all") {
-          const travelAgentsIds = response.flatMap((request: any) => (request.travel_agency?.users ?? []).map((user: any) => user.id));
-          // Travel agents see all requests except those in early stages (before they make reservations)
-          // Status shows only after reservations are completed (In Progress onwards)
-          response = response.filter((record: any) => !["Pending Review", "Denied", "Cancelled", "Changes Needed", "Pending Reservations"].includes(record.status) && travelAgentsIds.includes(authState.userId));
-
+        if (endpoint === "/requests/reserved-history") {
+          response = response.filter((record: any) => !["Pending Review", "Denied", "Cancelled", "Changes Needed", "Pending Reservations"].includes(record.status));
         }
         if (endpoint === "/requests/to-approve-SOI") {
           response = response.filter((record: any) => ["Pending Accounting Approval"].includes(record.status) && record.id_SOI === authState.userId);

--- a/src/pages/Refunds/Refunds.tsx
+++ b/src/pages/Refunds/Refunds.tsx
@@ -80,7 +80,7 @@ export const Refunds = () => {
       try {
         setLoading(true);
 
-        const response = await getRequest("/requests/all");
+        const response = await getRequest("/requests/user");
         setTrips(response.filter((trip: Trip) => trip.status === "In Progress").map((trip: any) => {
           const sortedDestinations = [...(trip.requests_destinations || [])].sort(
             (a: any, b: any) => a.destination_order - b.destination_order

--- a/src/pages/Refunds/Vouchers.tsx
+++ b/src/pages/Refunds/Vouchers.tsx
@@ -119,11 +119,11 @@ export const Vouchers = () => {
         formDataToSend.append("status", "pending_voucher");
         formDataToSend.append("currency", rowData.currency || "MXN");
         if (rowData.XMLFile) {
-          formDataToSend.append("file_url_xml", rowData.XMLFile);
+          formDataToSend.append("xml", rowData.XMLFile);
         }
 
         if (rowData.PDFFile) {
-          formDataToSend.append("file_url_pdf", rowData.PDFFile);
+          formDataToSend.append("pdf", rowData.PDFFile);
         }
 
         await postRequest("/vouchers/upload", formDataToSend);


### PR DESCRIPTION
This pull request updates the logic for displaying travel records and handling voucher uploads, primarily affecting how travel agents and users see requests and how files are sent during voucher submissions. The main goal is to ensure travel agents only see properly reserved requests and to standardize file upload fields.

**Travel records filtering and access:**

* Travel agents now see only requests with reservations completed (excluding early-stage statuses) by introducing a new `/requests/reserved-history` endpoint and updating the permission checks in `Historial.tsx`. [[1]](diffhunk://#diff-8c6e241bcb3fe6e376fc0319e643541edf98410f9b23164ad719f171ec921e93L107-R110) [[2]](diffhunk://#diff-8c6e241bcb3fe6e376fc0319e643541edf98410f9b23164ad719f171ec921e93L118-R122)
* The comment and changelog at the top of `Historial.tsx` were updated to reflect that travel agents now see all reserved requests, clarifying previous behavior.

**Voucher upload improvements:**

* The voucher upload logic now uses standardized field names (`xml` and `pdf` instead of `file_url_xml` and `file_url_pdf`) when sending files, ensuring consistency with backend expectations.

**Other adjustments:**

* The refunds page now fetches only the current user's requests instead of all requests, likely improving performance and data privacy.