### PR TITLE
bugfix(histroy + requests + vouchers): Travel agent reservations history + requests shorter id + company configurable expiration vouchers date

### DIFF
--- a/src/components/RefreshButton.tsx
+++ b/src/components/RefreshButton.tsx
@@ -8,15 +8,20 @@
 
 import { MdRefresh } from "react-icons/md";
 
+interface RefreshButtonProps {
+  onClick?: () => void;
+}
+
 /**
  * FunctionName: RefreshButton, renders a circular refresh icon button with hover styling.
- * Input: none
+ * Input: onClick — optional callback fired when the button is clicked.
  * Output: JSX button element containing a refresh icon.
  */
-const RefreshButton = () => {
+const RefreshButton = ({ onClick }: RefreshButtonProps) => {
 
     return (
         <button
+            onClick={onClick}
             className="p-2 bg-[var(--color-page-bg)] rounded-md shadow hover:bg-[var(--color-card-bg)]"
         >
             <MdRefresh className="h-6 w-6 text-[var(--color-page-text)]" />

--- a/src/components/Refunds/FilePreviewer.tsx
+++ b/src/components/Refunds/FilePreviewer.tsx
@@ -39,13 +39,23 @@ const FilePreviewer = ({ file, fileIndex, showDownload = true }: FilePreviewerPr
     return (
         <>
             <div className="grid grid-cols-1 md:grid-cols-3 w-full mb-4">
-                <iframe
-                  src={`${file.file_url_pdf}#navpanes=0&view=FitH`}
-                  width="100%"
-                  height="100%"
-                  title={`Comprobante de Solicitud ${fileIndex + 1}`}
-                  className="border-0 col-span-1 md:col-span-2 h-64 md:h-96"
-                />
+                        {file.file_url_pdf ? (
+                  <iframe
+                    src={`${file.file_url_pdf}#navpanes=0&view=FitH`}
+                    width="100%"
+                    height="100%"
+                    title={`Comprobante de Solicitud ${fileIndex + 1}`}
+                    className="border-0 col-span-1 md:col-span-2 h-64 md:h-96"
+                  />
+                ) : (
+                  <div className="col-span-1 md:col-span-2 h-64 md:h-96 flex flex-col items-center justify-center bg-[var(--color-page-bg)] border border-dashed border-gray-400 rounded-md gap-3">
+                    <span className="text-4xl">📄</span>
+                    <p className="text-sm font-medium text-[var(--color-page-text)]">
+                      {file.file_url_xml.split('/').pop() ?? `comprobante${fileIndex + 1}.xml`}
+                    </p>
+                    <p className="text-xs text-gray-400">{t('refundAcceptance.noPreview')}</p>
+                  </div>
+                )}
 
                 <div className="flex flex-col bg-[var(--color-page-bg)] p-6 gap-3 col-span-1">
                   <p id={`class-file-${fileIndex}`} className="text-[var(--color-page-text)]"><span className="font-semibold text-[var(--color-page-text-title)]">{t('refundAcceptance.voucherClass')}: </span>{file.class}</p>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -4,9 +4,7 @@
  *              and permission-based navigation links using SidebarOption items.
  * Authors: Original Moncarca team
  * Last Modification made:
- * 04/05/2026 [Rebeca-Davila] Changed colors and included switch for dark mode
- * 05/05/2026 [Santiago Coronado Hernández] Added notifications section.
- *            [Julio Rodríguez] Hide business-role menu items for pure admin users (is_system_admin or is_company_admin).
+ * 19/05/2026 [Julio Rodriguez]: Hide travel history link for admin users; use view_travel_agent_history for TA history link; fix duplicated label for travel agents.
  */
 
 // ***************** images *****************
@@ -56,7 +54,7 @@ function Sidebar({ user, onNavigate }: { user: AuthState, onNavigate?: () => voi
             {!isAdmin && user.userPermissions.includes("create_request" as Permission) && (
               <SidebarOption label={t('sidebar.createRequest')} pathIcon="/assets/crear_solicitud_de_viaje.png" link="/requests/create" onClick={onNavigate}/>
             )}
-            {user.userPermissions.includes("view_own_requests" as Permission) && (
+            {!isAdmin && user.userPermissions.includes("view_own_requests" as Permission) && (
               <SidebarOption label={t('sidebar.travelHistory')} pathIcon="/assets/historial_de_viajes.png" link="/history" onClick={onNavigate}/>
             )}
             {!isAdmin && user.userPermissions.includes("upload_vouchers" as Permission) && (
@@ -83,8 +81,8 @@ function Sidebar({ user, onNavigate }: { user: AuthState, onNavigate?: () => voi
             {/* {user.userPermissions.includes("submit_reservations" as Permission) && (
               <SidebarOption label="Formulario de ingreso de reservación" pathIcon="/assets/formulario_de_ingreso_de_reservacion.png" link=""/>
             )} */}
-            {!isAdmin && user.userPermissions.includes("view_assigned_requests_readonly" as Permission) && user.userPermissions.includes("submit_reservations" as Permission) && (
-              <SidebarOption label={t('sidebar.travelHistory')} pathIcon="/assets/historial_de_viajes_reservados.png" link="/history" onClick={onNavigate}/>
+            {!isAdmin && user.userPermissions.includes("view_travel_agent_history" as Permission) && (
+              <SidebarOption label={t('sidebar.reservedHistory')} pathIcon="/assets/historial_de_viajes_reservados.png" link="/history" onClick={onNavigate}/>
             )}
             {user.isSystemAdmin && (
               <SidebarOption label={t('sidebar.newCompany')} pathIcon="/assets/crear_solicitud_de_viaje.png" link="/admin/companies/new" onClick={onNavigate}/>
@@ -94,9 +92,6 @@ function Sidebar({ user, onNavigate }: { user: AuthState, onNavigate?: () => voi
             )}
             {user.isCompanyAdmin && (
               <SidebarOption label={t('sidebar.rules')} pathIcon="/assets/historial_de_viajes.png" link="/admin/rules" onClick={onNavigate}/>
-            )}
-            {(user.isCompanyAdmin || user.isSystemAdmin) && (
-              <SidebarOption label={t('sidebar.notifications')} pathIcon="/assets/crear_solicitud_de_viaje.png" link="/admin/notifications" onClick={onNavigate}/>
             )}
         </ul>
         <div className="flex gap-7 items-center p-2 mt-10">

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -64,7 +64,7 @@ function Sidebar({ user, onNavigate }: { user: AuthState, onNavigate?: () => voi
               <SidebarOption label={t('sidebar.tripsToApprove')} pathIcon="/assets/viajes_por_aprobar.png" link="/approvals" onClick={onNavigate}/>
             )}
             {!isAdmin && user.userPermissions.includes("view_approved_request_history" as Permission) && (
-              <SidebarOption label={t('sidebar.approvalHistory')} pathIcon="/assets/historial_de_viajes_aprobados.png" link="/history" onClick={onNavigate}/>
+              <SidebarOption label={t('sidebar.approvalHistory')} pathIcon="/assets/historial_de_viajes_aprobados.png" link="/history?view=approvals" onClick={onNavigate}/>
             )}
             {!isAdmin && user.userPermissions.includes("approve_vouchers" as Permission) && (
               <SidebarOption label={t('sidebar.vouchersAndRefunds')} pathIcon="/assets/comprobantes_de_gastos_por_aprobar.png" link="/refunds-review" onClick={onNavigate}/>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -93,6 +93,9 @@ function Sidebar({ user, onNavigate }: { user: AuthState, onNavigate?: () => voi
             {user.isCompanyAdmin && (
               <SidebarOption label={t('sidebar.rules')} pathIcon="/assets/historial_de_viajes.png" link="/admin/rules" onClick={onNavigate}/>
             )}
+            {user.isCompanyAdmin && (
+              <SidebarOption label={t('sidebar.notifications')} pathIcon="/assets/crear_solicitud_de_viaje.png" link="/admin/notifications" onClick={onNavigate}/>
+            )}
         </ul>
         <div className="flex gap-7 items-center p-2 mt-10">
             <DarkModeButton className="block md:hidden"></DarkModeButton>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -75,6 +75,9 @@ function Sidebar({ user, onNavigate }: { user: AuthState, onNavigate?: () => voi
             {!isAdmin && user.userPermissions.includes("check_budgets" as Permission) && (
               <SidebarOption label={t('sidebar.vouchersToRegister')} pathIcon="/assets/reembolsos_por_aprobar.png" link="/check-refunds" onClick={onNavigate}/>
             )}
+            {!isAdmin && user.userPermissions.includes("check_budgets" as Permission) && (
+              <SidebarOption label={t('sidebar.accountingExport')} pathIcon="/assets/historial_de_reembolsos_aprobados.png" link="/accounting/export" onClick={onNavigate}/>
+            )}
             {!isAdmin && user.userPermissions.includes("submit_reservations" as Permission) && (
               <SidebarOption label={t('sidebar.tripsToBook')} pathIcon="/assets/viajes_por_reservar.png" link="/bookings" onClick={onNavigate}/>
             )}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -70,7 +70,7 @@ function Sidebar({ user, onNavigate }: { user: AuthState, onNavigate?: () => voi
               <SidebarOption label={t('sidebar.vouchersAndRefunds')} pathIcon="/assets/comprobantes_de_gastos_por_aprobar.png" link="/refunds-review" onClick={onNavigate}/>
             )}
             {!isAdmin && user.userPermissions.includes("check_budgets" as Permission) && (
-              <SidebarOption label={t('sidebar.tripsToRegister')} pathIcon="/assets/historial_de_reembolsos_aprobados.png" link="/history" onClick={onNavigate}/>
+              <SidebarOption label={t('sidebar.tripsToRegister')} pathIcon="/assets/historial_de_reembolsos_aprobados.png" link="/history?view=soi" onClick={onNavigate}/>
             )}
             {!isAdmin && user.userPermissions.includes("check_budgets" as Permission) && (
               <SidebarOption label={t('sidebar.vouchersToRegister')} pathIcon="/assets/reembolsos_por_aprobar.png" link="/check-refunds" onClick={onNavigate}/>

--- a/src/hooks/auth/authContext.tsx
+++ b/src/hooks/auth/authContext.tsx
@@ -3,7 +3,7 @@
  * Description: Authentication and authorization context for the frontend. Provides auth state (user info + permissions), login session validation via profile endpoint, logout handling, and route protection components (basic auth + permission-based guards).
  * Authors: Original Moncarca team
  * Last Modification made:
- * 14/05/2026 [Diego de la Vega] Integrated flight search and reservation flow updates.
+ * 19/05/2026 [Julio Rodriguez] Added new flags and permissions for travel agent role; updated profile fetching logic to map these permissions.
  */
 
 import React, { createContext, useContext, ReactNode, useEffect } from "react";
@@ -301,16 +301,20 @@ export const PermissionProtectedRoute: React.FC<
 interface FlagProtectedRouteProps {
   requireSystemAdmin?: boolean;
   requireCompanyAdmin?: boolean;
+  requireCompanyAdminOnly?: boolean;
   children: ReactNode;
 }
 
 /**
  * FlagProtectedRoute, protects routes by checking isSystemAdmin or isCompanyAdmin flags.
+ * requireCompanyAdmin: allows companyAdmin OR systemAdmin.
+ * requireCompanyAdminOnly: allows ONLY companyAdmin — systemAdmin is explicitly blocked.
  * Redirects to /unauthorized when the caller lacks the required admin flag.
  */
 export const FlagProtectedRoute: React.FC<FlagProtectedRouteProps> = ({
   requireSystemAdmin,
   requireCompanyAdmin,
+  requireCompanyAdminOnly,
   children,
 }) => {
   const { authState } = useAuth();
@@ -318,6 +322,7 @@ export const FlagProtectedRoute: React.FC<FlagProtectedRouteProps> = ({
   if (!authState.isAuthenticated) return <Navigate to="/" replace />;
   if (requireSystemAdmin && !authState.isSystemAdmin) return <Navigate to="/unauthorized" replace />;
   if (requireCompanyAdmin && !authState.isCompanyAdmin && !authState.isSystemAdmin) return <Navigate to="/unauthorized" replace />;
+  if (requireCompanyAdminOnly && !authState.isCompanyAdmin) return <Navigate to="/unauthorized" replace />;
 
   return <>{children}</>;
 };

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -13,7 +13,8 @@
     "newCompany": "New company",
     "userList": "User list",
     "rules": "Rules",
-    "notifications": "Notifications"
+    "notifications": "Notifications",
+    "reservedHistory": "Reserved travel history"
   },
   "dashboard": {
     "createRequest": "Create travel request",
@@ -28,7 +29,8 @@
     "reservedHistory": "Reserved travel history",
     "newCompany": "New company",
     "userList": "User list",
-    "rules": "Rules"
+    "rules": "Rules",
+    "notifications": "Notifications"
   },
   "header": {
     "logout": "Log out"
@@ -586,7 +588,15 @@
       "successEditActor": "Actor updated successfully.",
       "errorEditActor": "Error updating actor.",
       "successDeleteActor": "Actor deleted successfully.",
-      "errorDeleteActor": "Error deleting actor."
+      "errorDeleteActor": "Error deleting actor.",
+      "actorTypeOptionalLabel": "Approver type (optional)",
+      "actorTypeNone": "No approver defined",
+      "actorTypeManager": "Direct manager",
+      "actorTypeUser": "Specific user",
+      "selectionModeAny": "Any",
+      "selectionModeAll": "All",
+      "cecoAppliesTo": "Applicable CECO",
+      "cecoAll": "All CECOs"
     },
     "notifications": {
       "title": "Notifications",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -14,7 +14,8 @@
     "userList": "User list",
     "rules": "Rules",
     "notifications": "Notifications",
-    "reservedHistory": "Reserved travel history"
+    "reservedHistory": "Reserved travel history",
+    "accountingExport": "Export accounting polizas"
   },
   "dashboard": {
     "createRequest": "Create travel request",
@@ -25,6 +26,7 @@
     "vouchersToApprove": "Expense vouchers to approve",
     "tripsToRegister": "Trips to register",
     "refundsToRegister": "Refunds to register",
+    "accountingExport": "Export accounting polizas",
     "tripsToBook": "Trips to book",
     "reservedHistory": "Reserved travel history",
     "newCompany": "New company",
@@ -663,5 +665,24 @@
   "theme": {
     "dark": "Dark mode",
     "light": "Light mode"
+  },
+  "accounting": {
+    "title": "Export accounting polizas",
+    "subtitle": "Generate and download the SAP poliza JSON for each completed trip.",
+    "loading": "Loading trips...",
+    "noRequests": "No completed trips to export.",
+    "polizaReady": "Poliza generated and downloaded successfully.",
+    "errorLoad": "Error loading completed trips.",
+    "errorGenerate": "Error generating poliza.",
+    "generating": "Generating...",
+    "generateButton": "Generate poliza",
+    "tableHeaders": {
+      "folio": "Folio",
+      "employee": "Employee",
+      "title": "Trip name",
+      "advance": "Advance",
+      "date": "Date",
+      "actions": "Actions"
+    }
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -596,7 +596,13 @@
       "selectionModeAny": "Any",
       "selectionModeAll": "All",
       "cecoAppliesTo": "Applicable CECO",
-      "cecoAll": "All CECOs"
+      "cecoAll": "All CECOs",
+      "voucherDeadlineTitle": "Expense Submission Deadline",
+      "voucherDeadlineDays": "Days after trip end",
+      "voucherDeadlineDaysLabel": "days",
+      "voucherDeadlineSave": "Save",
+      "voucherDeadlineSuccess": "Deadline updated successfully.",
+      "voucherDeadlineError": "Error saving deadline."
     },
     "notifications": {
       "title": "Notifications",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -377,6 +377,7 @@
     "errorCompleting": "Error completing verification. Please try again.",
     "downloadXml": "Download XML",
     "downloadPdf": "Download PDF",
+    "noPreview": "Preview not available",
     "voucherClass": "Class",
     "amountMxn": "Amount (MXN)",
     "originalAmount": "Original amount",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -596,7 +596,13 @@
       "selectionModeAny": "Cualquiera",
       "selectionModeAll": "Todos",
       "cecoAppliesTo": "CECO al que aplica",
-      "cecoAll": "Todos los CECOs"
+      "cecoAll": "Todos los CECOs",
+      "voucherDeadlineTitle": "Límite de comprobación de gastos",
+      "voucherDeadlineDays": "Días después del fin del viaje",
+      "voucherDeadlineDaysLabel": "días",
+      "voucherDeadlineSave": "Guardar",
+      "voucherDeadlineSuccess": "Límite actualizado exitosamente.",
+      "voucherDeadlineError": "Error al guardar el límite."
     },
     "notifications": {
       "title": "Notificaciones",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -377,6 +377,7 @@
     "errorCompleting": "Error al completar la verificación. Intenta de nuevo.",
     "downloadXml": "Descargar XML",
     "downloadPdf": "Descargar PDF",
+    "noPreview": "Vista previa no disponible",
     "voucherClass": "Clase",
     "amountMxn": "Cantidad (MXN)",
     "originalAmount": "Cantidad original",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -14,7 +14,8 @@
     "userList": "Lista de usuarios",
     "rules": "Reglas",
     "notifications": "Notificaciones",
-    "reservedHistory": "Historial de viajes reservados"
+    "reservedHistory": "Historial de viajes reservados",
+    "accountingExport": "Exportar pólizas contables"
   },
   "dashboard": {
     "createRequest": "Crear solicitud de viaje",
@@ -25,6 +26,7 @@
     "vouchersToApprove": "Comprobantes de gastos por aprobar",
     "tripsToRegister": "Viajes por registrar",
     "refundsToRegister": "Reembolsos por registrar",
+    "accountingExport": "Exportar pólizas contables",
     "tripsToBook": "Viajes por reservar",
     "reservedHistory": "Historial de viajes reservados",
     "newCompany": "Crear empresa",
@@ -663,5 +665,24 @@
   "theme": {
     "dark": "Modo oscuro",
     "light": "Modo claro"
+  },
+  "accounting": {
+    "title": "Exportar pólizas contables",
+    "subtitle": "Genera y descarga el JSON de póliza SAP para cada viaje completado.",
+    "loading": "Cargando viajes...",
+    "noRequests": "No hay viajes completados por exportar.",
+    "polizaReady": "Póliza generada y descargada correctamente.",
+    "errorLoad": "Error al cargar los viajes completados.",
+    "errorGenerate": "Error al generar la póliza.",
+    "generating": "Generando...",
+    "generateButton": "Generar póliza",
+    "tableHeaders": {
+      "folio": "Folio",
+      "employee": "Empleado",
+      "title": "Nombre del viaje",
+      "advance": "Anticipo",
+      "date": "Fecha",
+      "actions": "Acciones"
+    }
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -13,7 +13,8 @@
     "newCompany": "Nueva empresa",
     "userList": "Lista de usuarios",
     "rules": "Reglas",
-    "notifications": "Notificaciones"
+    "notifications": "Notificaciones",
+    "reservedHistory": "Historial de viajes reservados"
   },
   "dashboard": {
     "createRequest": "Crear solicitud de viaje",
@@ -28,7 +29,8 @@
     "reservedHistory": "Historial de viajes reservados",
     "newCompany": "Crear empresa",
     "userList": "Lista de usuarios",
-    "rules": "Reglas"
+    "rules": "Reglas",
+    "notifications": "Notificaciones"
   },
   "header": {
     "logout": "Cerrar sesión"
@@ -586,7 +588,15 @@
       "successEditActor": "Actor actualizado exitosamente.",
       "errorEditActor": "Error al actualizar el actor.",
       "successDeleteActor": "Actor eliminado exitosamente.",
-      "errorDeleteActor": "Error al eliminar el actor."
+      "errorDeleteActor": "Error al eliminar el actor.",
+      "actorTypeOptionalLabel": "Tipo de aprobador (opcional)",
+      "actorTypeNone": "Sin aprobador definido",
+      "actorTypeManager": "Gerente directo",
+      "actorTypeUser": "Usuario específico",
+      "selectionModeAny": "Cualquiera",
+      "selectionModeAll": "Todos",
+      "cecoAppliesTo": "CECO al que aplica",
+      "cecoAll": "Todos los CECOs"
     },
     "notifications": {
       "title": "Notificaciones",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -49,6 +49,7 @@ import { Approvals } from "./pages/Approvals/Approvals.tsx";
 import { RefundsReview } from "./pages/Refunds/RefundsReview.tsx";
 import { CheckRefunds } from "./pages/Refunds/CheckRefunds.tsx";
 import FlightSearch from "./pages/FlightSearch.tsx";
+import { AccountingExport } from "./pages/Accounting/AccountingExport.tsx";
 
 /**
  * router, defines the application's route tree.
@@ -125,6 +126,10 @@ export const router = createBrowserRouter([
       {
         path: "/check-refunds",
         element: <CheckRefunds />,
+      },
+      {
+        path: "/accounting/export",
+        element: <AccountingExport />,
       },
       {
         path: "/bookings",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,7 +4,7 @@
  * configures React Router routes (public and protected), and sets up TanStack Query provider for server state management.
  * Authors: Original Moncarca team
  * Last Modification made:
- * 11/05/2026 [Diego de la Vega] Integration of flight search panel into reservations page and updated last modification comment.
+ * 19/05/2026 [Julio Rodriguez] Updated admin guard for notifications page to be company-admin only; added new routes for notifications management and travel agent history; integrated new permissions and flags into route protection logic.
  */
 
 import { StrictMode } from "react";
@@ -152,7 +152,7 @@ export const router = createBrowserRouter([
       },
       {
         path: "/admin/notifications",
-        element: <FlagProtectedRoute requireCompanyAdmin><AdminNotifications /></FlagProtectedRoute>,
+        element: <FlagProtectedRoute requireCompanyAdminOnly><AdminNotifications /></FlagProtectedRoute>,
       },
       {
         path: "/admin/companies/new",

--- a/src/pages/Accounting/AccountingExport.tsx
+++ b/src/pages/Accounting/AccountingExport.tsx
@@ -1,0 +1,178 @@
+/**
+ * AccountingExport.tsx
+ * Description: Page for SOI users to generate and download accounting poliza JSON files
+ *              for completed trips. Shows a table of completed requests with a generate
+ *              button per row. On success the poliza JSON is auto-downloaded as a file.
+ * Authors: DebugStudio Team
+ * Last Modification made:
+ * 20/05/2026 [Julio Rodriguez] Created page.
+ */
+
+import { useState, useEffect } from "react";
+import { toast } from "react-toastify";
+import { useTranslation } from "react-i18next";
+import GoBack from "../../components/GoBack";
+import RefreshButton from "../../components/RefreshButton";
+import formatDate from "../../utils/formatDate";
+import formatMoney from "../../utils/formatMoney";
+import { getRequest } from "../../utils/apiService";
+
+interface CompletedRequest {
+  id: string;
+  request_num: number;
+  createdAt: string;
+  title: string;
+  advance_money: number;
+  currency: string | null;
+  user?: {
+    name: string;
+    last_name: string;
+    employee_num: string | null;
+  };
+}
+
+/**
+ * buildFolio — Formats a request into its YYYY-NNN folio.
+ */
+function buildFolio(req: CompletedRequest): string {
+  const year = new Date(req.createdAt).getFullYear();
+  return `${year}-${req.request_num.toString().padStart(3, "0")}`;
+}
+
+/**
+ * downloadJson — Triggers a browser download of a JSON object as a .json file.
+ */
+function downloadJson(data: unknown, filename: string) {
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * AccountingExport, main component. Fetches completed requests and renders
+ * a table where the SOI can generate and download poliza JSON per trip.
+ */
+export const AccountingExport = () => {
+  const { t } = useTranslation();
+  const [requests, setRequests] = useState<CompletedRequest[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [generatingId, setGeneratingId] = useState<string | null>(null);
+
+  const fetchRequests = async () => {
+    try {
+      setLoading(true);
+      const data = await getRequest("/accounting/requests/completed");
+      setRequests(data);
+    } catch {
+      toast.error(t("accounting.errorLoad"));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchRequests();
+  }, []);
+
+  /**
+   * handleGenerate — Calls the poliza endpoint and triggers a JSON file download.
+   */
+  const handleGenerate = async (req: CompletedRequest) => {
+    if (generatingId) return;
+    setGeneratingId(req.id);
+    try {
+      const data = await getRequest(`/accounting/requests/${req.id}/poliza`);
+      const folio = buildFolio(req);
+      downloadJson(data, `poliza_${folio}.json`);
+      toast.success(t("accounting.polizaReady"));
+    } catch (err) {
+      const rawMsg = (err as { response?: { data?: { message?: unknown } } })?.response?.data?.message;
+      const apiMessage =
+        typeof rawMsg === "string"
+          ? rawMsg
+          : Array.isArray(rawMsg)
+          ? (rawMsg as string[]).join(", ")
+          : null;
+      toast.error(apiMessage ?? t("accounting.errorGenerate"));
+    } finally {
+      setGeneratingId(null);
+    }
+  };
+
+  return (
+    <>
+      <GoBack />
+      <div className="max-w-full p-6 bg-[var(--color-card-bg)] rounded-lg shadow-xl">
+        <div className="flex items-center justify-between mb-4">
+          <div>
+            <h1 className="text-2xl font-bold text-[var(--color-page-text-title)]">
+              {t("accounting.title")}
+            </h1>
+            <p className="text-sm text-[var(--color-page-text)] mt-1">{t("accounting.subtitle")}</p>
+          </div>
+          <RefreshButton onClick={fetchRequests} />
+        </div>
+
+        {loading ? (
+          <p className="text-[var(--color-page-text)]">{t("accounting.loading")}</p>
+        ) : requests.length === 0 ? (
+          <p className="text-[var(--color-page-text)]">{t("accounting.noRequests")}</p>
+        ) : (
+          <div className="overflow-x-auto mb-4">
+            <table className="w-full min-w-[900px] text-sm text-left border-separate border-spacing-y-2">
+              <thead>
+                <tr className="text-xs text-white uppercase bg-[#0a2c6d]">
+                  <th className="px-4 py-2 rounded-l-lg">{t("accounting.tableHeaders.folio")}</th>
+                  <th className="px-4 py-2">{t("accounting.tableHeaders.employee")}</th>
+                  <th className="px-4 py-2">{t("accounting.tableHeaders.title")}</th>
+                  <th className="px-4 py-2 text-right">{t("accounting.tableHeaders.advance")}</th>
+                  <th className="px-4 py-2">{t("accounting.tableHeaders.date")}</th>
+                  <th className="px-4 py-2 text-center rounded-r-lg">{t("accounting.tableHeaders.actions")}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {requests.map((req) => {
+                  const folio = buildFolio(req);
+                  const employeeName = req.user
+                    ? `${req.user.name} ${req.user.last_name}`
+                    : "—";
+                  const isGenerating = generatingId === req.id;
+                  return (
+                    <tr key={req.id} className="bg-[#4C6997] text-white text-center">
+                      <td className="px-4 py-3 rounded-l-lg font-mono font-semibold text-left">
+                        {folio}
+                      </td>
+                      <td className="px-4 py-3 text-left">{employeeName}</td>
+                      <td className="px-4 py-3 max-w-xs truncate text-left">{req.title}</td>
+                      <td className="px-4 py-3 text-right">
+                        {Number(req.advance_money) > 0
+                          ? formatMoney(req.advance_money)
+                          : "—"}
+                      </td>
+                      <td className="px-4 py-3 text-left">{formatDate(req.createdAt)}</td>
+                      <td className="px-4 py-3 rounded-r-lg text-center">
+                        <button
+                          onClick={() => handleGenerate(req)}
+                          disabled={isGenerating || generatingId !== null}
+                          className="px-3 py-1.5 rounded text-sm font-medium text-white bg-[var(--dark-blue)] hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-opacity"
+                        >
+                          {isGenerating
+                            ? t("accounting.generating")
+                            : t("accounting.generateButton")}
+                        </button>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </>
+  );
+};

--- a/src/pages/Admin/AdminRules.tsx
+++ b/src/pages/Admin/AdminRules.tsx
@@ -103,7 +103,7 @@ export default function AdminRules() {
   const [deleting, setDeleting] = useState(false);
   const [cecos, setCecos] = useState<CostCenter[]>([]);
   const [companyName, setCompanyName] = useState<string | null>(null);
-  const [voucherDeadlineDays, setVoucherDeadlineDays] = useState<number | null>(null);
+  const [, setVoucherDeadlineDays] = useState<number | null>(null);
   const [deadlineInput, setDeadlineInput] = useState<string>("");
   const [savingDeadline, setSavingDeadline] = useState(false);
 

--- a/src/pages/Admin/AdminRules.tsx
+++ b/src/pages/Admin/AdminRules.tsx
@@ -103,7 +103,7 @@ export default function AdminRules() {
   const [deleting, setDeleting] = useState(false);
   const [cecos, setCecos] = useState<CostCenter[]>([]);
   const [companyName, setCompanyName] = useState<string | null>(null);
-  const [voucherDeadlineDays, setVoucherDeadlineDays] = useState<number | null>(null);
+  const [setVoucherDeadlineDays] = useState<number | null>(null);
   const [deadlineInput, setDeadlineInput] = useState<string>("");
   const [savingDeadline, setSavingDeadline] = useState(false);
 

--- a/src/pages/Admin/AdminRules.tsx
+++ b/src/pages/Admin/AdminRules.tsx
@@ -103,7 +103,7 @@ export default function AdminRules() {
   const [deleting, setDeleting] = useState(false);
   const [cecos, setCecos] = useState<CostCenter[]>([]);
   const [companyName, setCompanyName] = useState<string | null>(null);
-  const [setVoucherDeadlineDays] = useState<number | null>(null);
+  const [voucherDeadlineDays, setVoucherDeadlineDays] = useState<number | null>(null);
   const [deadlineInput, setDeadlineInput] = useState<string>("");
   const [savingDeadline, setSavingDeadline] = useState(false);
 

--- a/src/pages/Admin/AdminRules.tsx
+++ b/src/pages/Admin/AdminRules.tsx
@@ -95,6 +95,7 @@ export default function AdminRules() {
   const canLoad = Boolean(companyId);
 
   const [rules, setRules] = useState<ApprovalRule[]>([]);
+  const [filterActive, setFilterActive] = useState<'all' | 'active' | 'inactive'>('all');
   const [loading, setLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
   const [form, setForm] = useState(emptyForm);
@@ -147,8 +148,9 @@ export default function AdminRules() {
     }
   }, []);
 
-  const totalPages = Math.ceil(rules.length / ITEMS_PER_PAGE);
-  const paginated = rules.slice((currentPage - 1) * ITEMS_PER_PAGE, currentPage * ITEMS_PER_PAGE);
+  const filteredRules = filterActive === 'all' ? rules : rules.filter((r) => r.is_active === (filterActive === 'active'));
+  const totalPages = Math.ceil(filteredRules.length / ITEMS_PER_PAGE);
+  const paginated = filteredRules.slice((currentPage - 1) * ITEMS_PER_PAGE, currentPage * ITEMS_PER_PAGE);
 
   const changePage = (page: number) => {
     if (page < 1 || page > totalPages) return;
@@ -398,6 +400,15 @@ export default function AdminRules() {
             {companyId ? `${t('admin.notifications.activeCompany')} ${companyName ?? companyId}` : t('admin.notifications.companyUnavailable')}
           </p>
           <div className="flex items-center gap-3">
+            <select
+              value={filterActive}
+              onChange={(e) => { setFilterActive(e.target.value as 'all' | 'active' | 'inactive'); setCurrentPage(1); }}
+              className={selectClass}
+            >
+              <option value="all">{t('admin.rules.all')}</option>
+              <option value="active">{t('admin.rules.active')}</option>
+              <option value="inactive">{t('admin.rules.inactive')}</option>
+            </select>
             <button
               onClick={() => navigate('/admin/notifications')}
               className="px-3 py-2 bg-[#f0f4ff] text-[#0a2c6d] text-sm rounded-md hover:bg-[#ebf0ff] transition-colors"
@@ -821,7 +832,7 @@ export default function AdminRules() {
                   <td className="px-4 py-3 rounded-l-lg">{r.code}</td>
                   <td className="px-4 py-3">{r.name}</td>
                   <td className="px-4 py-3">{r.description ?? "-"}</td>
-                  <td className="px-4 py-3">{r.applies_to}</td>
+                  <td className="px-4 py-3">{t(`admin.rules.${r.applies_to}`)}</td>
                   <td className="px-4 py-3">{r.level_order}</td>
                   <td className="px-4 py-3">{r.min_amount_mon ?? "-"}</td>
                   <td className="px-4 py-3">{r.max_amount_mon ?? "-"}</td>

--- a/src/pages/Admin/AdminRules.tsx
+++ b/src/pages/Admin/AdminRules.tsx
@@ -11,6 +11,8 @@
  *                              Fixed ceco_id DTO validator: @IsString instead of @IsUUID in approval-level-actor.dto.ts.
  *                              Show company name (not UUID) in header via GET /admin/companies/:id/info.
  *                              CECO selector always visible in create form (not hidden behind actor_type).
+ * 19/05/2026 [Julio Rodriguez] Replaced hardcoded Spanish strings with i18n t() calls; unified CECO display to show id+name;
+ *                              added description and applies_to fields to edit form.
  */
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -67,6 +69,8 @@ const emptyForm = {
 
 const emptyEditForm = {
   name: "",
+  description: "",
+  applies_to: "travel",
   min_amount_mon: "",
   max_amount_mon: "",
   required_approvals: 1,
@@ -199,6 +203,8 @@ export default function AdminRules() {
     setEditLevel(level);
     setEditForm({
       name: level.name,
+      description: level.description ?? "",
+      applies_to: level.applies_to ?? "travel",
       min_amount_mon: level.min_amount_mon !== null ? String(level.min_amount_mon) : "",
       max_amount_mon: level.max_amount_mon !== null ? String(level.max_amount_mon) : "",
       required_approvals: level.required_approvals,
@@ -223,8 +229,10 @@ export default function AdminRules() {
     try {
       const payload: Record<string, unknown> = {
         name: editForm.name,
+        applies_to: editForm.applies_to,
         required_approvals: Number(editForm.required_approvals),
         is_active: editForm.is_active,
+        ...(editForm.description !== "" && { description: editForm.description }),
         ...(editForm.min_amount_mon !== "" && { min_amount_mon: Number(editForm.min_amount_mon) }),
         ...(editForm.max_amount_mon !== "" && { max_amount_mon: Number(editForm.max_amount_mon) }),
       };
@@ -456,28 +464,28 @@ export default function AdminRules() {
                     <Input name="required_approvals" type="number" min={1} value={form.required_approvals} onChange={handleChange} required />
                   </div>
                   <div>
-                    <label className={labelClass}>Tipo de aprobador (opcional)</label>
+                    <label className={labelClass}>{t('admin.rules.actorTypeOptionalLabel')}</label>
                     <select name="actor_type" value={form.actor_type} onChange={handleChange} className={selectClass}>
-                      <option value="">Sin aprobador definido</option>
-                      <option value="MANAGER">Gerente directo</option>
-                      <option value="USER">Usuario específico</option>
+                      <option value="">{t('admin.rules.actorTypeNone')}</option>
+                      <option value="MANAGER">{t('admin.rules.actorTypeManager')}</option>
+                      <option value="USER">{t('admin.rules.actorTypeUser')}</option>
                     </select>
                   </div>
                   {form.actor_type && (
                     <div>
-                      <label className={labelClass}>Modo de selección</label>
+                      <label className={labelClass}>{t('admin.rules.selectionMode')}</label>
                       <select name="selection_mode" value={form.selection_mode} onChange={handleChange} className={selectClass}>
-                        <option value="any">Cualquiera</option>
-                        <option value="all">Todos</option>
+                        <option value="any">{t('admin.rules.selectionModeAny')}</option>
+                        <option value="all">{t('admin.rules.selectionModeAll')}</option>
                       </select>
                     </div>
                   )}
                   <div>
-                    <label className={labelClass}>CECO al que aplica</label>
+                    <label className={labelClass}>{t('admin.rules.cecoAppliesTo')}</label>
                     <select name="actor_ceco_id" value={form.actor_ceco_id} onChange={handleChange} className={selectClass}>
-                      <option value="">Todos los CECOs</option>
+                      <option value="">{t('admin.rules.cecoAll')}</option>
                       {cecos.map((c) => (
-                        <option key={c.id} value={c.id}>{c.id}</option>
+                        <option key={c.id} value={c.id}>{c.id}{c.name ? ` — ${c.name}` : ''}</option>
                       ))}
                     </select>
                   </div>
@@ -499,6 +507,18 @@ export default function AdminRules() {
                   <div className="sm:col-span-2">
                     <label className={labelClass}>{t('admin.rules.levelName')}</label>
                     <Input name="name" value={editForm.name} onChange={handleEditChange} required />
+                  </div>
+                  <div className="sm:col-span-2">
+                    <label className={labelClass}>{t('admin.rules.levelDescription')}</label>
+                    <Input name="description" value={editForm.description} onChange={handleEditChange} placeholder={t('admin.rules.levelDescriptionPlaceholder')} />
+                  </div>
+                  <div>
+                    <label className={labelClass}>{t('admin.rules.appliesTo')}</label>
+                    <select name="applies_to" value={editForm.applies_to} onChange={handleEditChange} className={selectClass}>
+                      <option value="travel">{t('admin.rules.travel')}</option>
+                      <option value="refund">{t('admin.rules.refund')}</option>
+                      <option value="all">{t('admin.rules.all')}</option>
+                    </select>
                   </div>
                   <div>
                     <label className={labelClass}>{t('admin.rules.minAmount')}</label>
@@ -599,21 +619,21 @@ export default function AdminRules() {
                     <label className={labelClass}>{t('admin.rules.actorType')}</label>
                     <select name="actor_type" value={actorForm.actor_type} onChange={handleActorFormChange} className={selectClass} required>
                       <option value="">—</option>
-                      <option value="MANAGER">Gerente directo</option>
-                      <option value="USER">Usuario específico</option>
+                      <option value="MANAGER">{t('admin.rules.actorTypeManager')}</option>
+                      <option value="USER">{t('admin.rules.actorTypeUser')}</option>
                     </select>
                   </div>
                   <div>
                     <label className={labelClass}>{t('admin.rules.selectionMode')}</label>
                     <select name="selection_mode" value={actorForm.selection_mode} onChange={handleActorFormChange} className={selectClass}>
-                      <option value="any">Cualquiera</option>
-                      <option value="all">Todos</option>
+                      <option value="any">{t('admin.rules.selectionModeAny')}</option>
+                      <option value="all">{t('admin.rules.selectionModeAll')}</option>
                     </select>
                   </div>
                   <div>
-                    <label className={labelClass}>CECO</label>
+                    <label className={labelClass}>{t('admin.rules.cecoAppliesTo')}</label>
                     <select name="ceco_id" value={actorForm.ceco_id} onChange={handleActorFormChange} className={selectClass}>
-                      <option value="">Todos los CECOs</option>
+                      <option value="">{t('admin.rules.cecoAll')}</option>
                       {cecos.map((c) => (
                         <option key={c.id} value={c.id}>{c.id}{c.name ? ` — ${c.name}` : ''}</option>
                       ))}
@@ -648,21 +668,21 @@ export default function AdminRules() {
                     <label className={labelClass}>{t('admin.rules.actorType')}</label>
                     <select name="actor_type" value={actorForm.actor_type} onChange={handleActorFormChange} className={selectClass} required>
                       <option value="">—</option>
-                      <option value="MANAGER">Gerente directo</option>
-                      <option value="USER">Usuario específico</option>
+                      <option value="MANAGER">{t('admin.rules.actorTypeManager')}</option>
+                      <option value="USER">{t('admin.rules.actorTypeUser')}</option>
                     </select>
                   </div>
                   <div>
                     <label className={labelClass}>{t('admin.rules.selectionMode')}</label>
                     <select name="selection_mode" value={actorForm.selection_mode} onChange={handleActorFormChange} className={selectClass}>
-                      <option value="any">Cualquiera</option>
-                      <option value="all">Todos</option>
+                      <option value="any">{t('admin.rules.selectionModeAny')}</option>
+                      <option value="all">{t('admin.rules.selectionModeAll')}</option>
                     </select>
                   </div>
                   <div>
-                    <label className={labelClass}>CECO</label>
+                    <label className={labelClass}>{t('admin.rules.cecoAppliesTo')}</label>
                     <select name="ceco_id" value={actorForm.ceco_id} onChange={handleActorFormChange} className={selectClass}>
-                      <option value="">Todos los CECOs</option>
+                      <option value="">{t('admin.rules.cecoAll')}</option>
                       {cecos.map((c) => (
                         <option key={c.id} value={c.id}>{c.id}{c.name ? ` — ${c.name}` : ''}</option>
                       ))}

--- a/src/pages/Admin/AdminRules.tsx
+++ b/src/pages/Admin/AdminRules.tsx
@@ -5,17 +5,11 @@
  *              Uses GET/POST/PATCH/DELETE /approval-engine/levels. company_id is derived server-side from JWT.
  * Authors: Original Monarca team
  * Last Modification made:
- * 13/05/2026 [Julio Rodriguez] Added CECO selector to inline actor form; loads CECOs from /admin/companies/:id/cost-centers.
- *                              Added edit and delete functionality with pending-request reassignment error handling.
- *                              Added ApprovalLevelActor management section per level (Tarea E).
- *                              Fixed ceco_id DTO validator: @IsString instead of @IsUUID in approval-level-actor.dto.ts.
- *                              Show company name (not UUID) in header via GET /admin/companies/:id/info.
- *                              CECO selector always visible in create form (not hidden behind actor_type).
  * 19/05/2026 [Julio Rodriguez] Replaced hardcoded Spanish strings with i18n t() calls; unified CECO display to show id+name;
  *                              added description and applies_to fields to edit form.
+ *                              Added voucher deadline section — PATCH /admin/companies/:id/settings.
  */
 import React, { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
 import { getRequest, postRequest, patchRequest, deleteRequest } from "../../utils/apiService";
 import { useAuth } from "../../hooks/auth/authContext";
 import GoBack from "../../components/GoBack";
@@ -109,6 +103,9 @@ export default function AdminRules() {
   const [deleting, setDeleting] = useState(false);
   const [cecos, setCecos] = useState<CostCenter[]>([]);
   const [companyName, setCompanyName] = useState<string | null>(null);
+  const [voucherDeadlineDays, setVoucherDeadlineDays] = useState<number | null>(null);
+  const [deadlineInput, setDeadlineInput] = useState<string>("");
+  const [savingDeadline, setSavingDeadline] = useState(false);
 
   // Actors section state
   const [selectedLevelForActors, setSelectedLevelForActors] = useState<ApprovalRule | null>(null);
@@ -120,8 +117,6 @@ export default function AdminRules() {
   const [actorToDelete, setActorToDelete] = useState<ApprovalLevelActor | null>(null);
   const [savingActor, setSavingActor] = useState(false);
   const [deletingActor, setDeletingActor] = useState(false);
-
-  const navigate = useNavigate();
 
   const fetchRules = async () => {
     setLoading(true);
@@ -143,7 +138,11 @@ export default function AdminRules() {
         .then((data) => setCecos(data))
         .catch(() => {});
       getRequest(`/admin/companies/${companyId}/info`)
-        .then((data) => setCompanyName(data.name ?? null))
+        .then((data) => {
+          setCompanyName(data.name ?? null);
+          setVoucherDeadlineDays(data.voucher_deadline_days ?? 7);
+          setDeadlineInput(String(data.voucher_deadline_days ?? 7));
+        })
         .catch(() => {});
     }
   }, []);
@@ -390,6 +389,24 @@ export default function AdminRules() {
     }
   };
 
+  const handleSaveDeadline = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!companyId) return;
+    const days = parseInt(deadlineInput, 10);
+    if (isNaN(days) || days < 1) return;
+    setSavingDeadline(true);
+    setMessage(null);
+    try {
+      const updated = await patchRequest(`/admin/companies/${companyId}/settings`, { voucher_deadline_days: days });
+      setVoucherDeadlineDays(updated.voucher_deadline_days);
+      setMessage({ text: t('admin.rules.voucherDeadlineSuccess'), error: false });
+    } catch {
+      setMessage({ text: t('admin.rules.voucherDeadlineError'), error: true });
+    } finally {
+      setSavingDeadline(false);
+    }
+  };
+
   return (
     <>
       <GoBack />
@@ -410,12 +427,6 @@ export default function AdminRules() {
               <option value="inactive">{t('admin.rules.inactive')}</option>
             </select>
             <button
-              onClick={() => navigate('/admin/notifications')}
-              className="px-3 py-2 bg-[#f0f4ff] text-[#0a2c6d] text-sm rounded-md hover:bg-[#ebf0ff] transition-colors"
-            >
-              {t('admin.rules.notifications')}
-            </button>
-            <button
               onClick={() => { setShowForm(!showForm); setMessage(null); }}
               disabled={!canLoad}
               className="px-4 py-2 bg-[#0a2c6d] text-white text-sm rounded-md hover:bg-[#0d3d94] transition-colors disabled:opacity-50"
@@ -430,6 +441,34 @@ export default function AdminRules() {
           <div className={`mb-4 p-3 rounded-md text-sm ${message.error ? "bg-red-100 text-red-700" : "bg-green-100 text-green-700"}`}>
             {message.text}
           </div>
+        )}
+
+        {canLoad && (
+          <section className="bg-[var(--color-page-bg)] border border-[var(--color-border)] rounded-md mb-6 p-5">
+            <h3 className="text-base font-semibold text-[var(--color-page-text-title)] mb-3">
+              {t('admin.rules.voucherDeadlineTitle')}
+            </h3>
+            <form onSubmit={handleSaveDeadline} className="flex items-end gap-4">
+              <div>
+                <label className={labelClass}>{t('admin.rules.voucherDeadlineDays')}</label>
+                <div className="flex items-center gap-2">
+                  <Input
+                    name="voucher_deadline_days"
+                    type="number"
+                    min={1}
+                    value={deadlineInput}
+                    onChange={(e) => setDeadlineInput(e.target.value)}
+                    required
+                    className="w-24"
+                  />
+                  <span className="text-sm text-[var(--color-page-text)]">{t('admin.rules.voucherDeadlineDaysLabel')}</span>
+                </div>
+              </div>
+              <Button type="submit" disabled={savingDeadline}>
+                {savingDeadline ? t('common.saving') : t('admin.rules.voucherDeadlineSave')}
+              </Button>
+            </form>
+          </section>
         )}
 
         {showForm && (

--- a/src/pages/Admin/AdminUsers.tsx
+++ b/src/pages/Admin/AdminUsers.tsx
@@ -38,6 +38,7 @@ export default function AdminUsers() {
   const [importing, setImporting] = useState(false);
   const [message, setMessage] = useState<{ text: string; error: boolean } | null>(null);
   const [currentPage, setCurrentPage] = useState(1);
+  const [companyName, setCompanyName] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const fetchUsers = async () => {
@@ -54,7 +55,14 @@ export default function AdminUsers() {
     }
   };
 
-  useEffect(() => { fetchUsers(); }, []);
+  useEffect(() => {
+    fetchUsers();
+    if (companyId) {
+      getRequest(`/admin/companies/${companyId}/info`)
+        .then((data) => setCompanyName(data.name ?? null))
+        .catch(() => {});
+    }
+  }, []);
 
   const totalPages = Math.ceil(users.length / ITEMS_PER_PAGE);
   const paginated = users.slice((currentPage - 1) * ITEMS_PER_PAGE, currentPage * ITEMS_PER_PAGE);
@@ -113,7 +121,7 @@ export default function AdminUsers() {
             </div>
           </div>
           <p className="text-sm text-gray-600">
-            {companyId ? `${t('admin.notifications.activeCompany')} ${companyId}` : t('admin.notifications.companyUnavailable')}
+            {companyId ? `${t('admin.notifications.activeCompany')} ${companyName ?? companyId}` : t('admin.notifications.companyUnavailable')}
           </p>
           <input ref={fileInputRef} type="file" accept=".json" className="hidden" onChange={handleFileUpload} />
         </div>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -74,6 +74,9 @@ export const Dashboard = ({title}:DashboardProps) => {
         {!isAdmin && authState.userPermissions.includes("check_budgets" as Permission) && (
           <Mosaic title={t('dashboard.refundsToRegister')} iconPath="/assets/reembolsos_por_aprobar.png" link="/check-refunds" id="check_refunds"/>
         )}
+        {!isAdmin && authState.userPermissions.includes("check_budgets" as Permission) && (
+          <Mosaic title={t('dashboard.accountingExport')} iconPath="/assets/historial_de_reembolsos_aprobados.png" link="/accounting/export" id="accounting_export"/>
+        )}
         {!isAdmin && authState.userPermissions.includes("submit_reservations" as Permission) && (
           <Mosaic title={t('dashboard.tripsToBook')} iconPath="/assets/viajes_por_reservar.png" link="/bookings" id="bookings"/>
         )}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -60,7 +60,7 @@ export const Dashboard = ({title}:DashboardProps) => {
           <Mosaic title={t('dashboard.tripsToApprove')} iconPath="/assets/viajes_por_aprobar.png" link="/approvals" id="approve_request"/>
         )}
         {!isAdmin && authState.userPermissions.includes("view_approved_request_history" as Permission) && (
-          <Mosaic title={t('dashboard.approvedHistory')} iconPath="/assets/historial_de_viajes_aprobados.png" link="/history" id="approved_requests"/>
+          <Mosaic title={t('dashboard.approvedHistory')} iconPath="/assets/historial_de_viajes_aprobados.png" link="/history?view=approvals" id="approved_requests"/>
         )}
         {!isAdmin && authState.userPermissions.includes("approve_vouchers" as Permission) && (
           <Mosaic title={t('dashboard.vouchersToApprove')} iconPath="/assets/comprobantes_de_gastos_por_aprobar.png" link="/refunds-review" id="approve_vouchers"/>
@@ -69,7 +69,7 @@ export const Dashboard = ({title}:DashboardProps) => {
           <Mosaic title="Reembolsos por aprobar" iconPath="/assets/reembolsos_por_aprobar.png" link=""/>
         )} */}
         {!isAdmin && authState.userPermissions.includes("check_budgets" as Permission) && (
-          <Mosaic title={t('dashboard.tripsToRegister')} iconPath="/assets/historial_de_reembolsos_aprobados.png" link="/history" id="check_budgets"/>
+          <Mosaic title={t('dashboard.tripsToRegister')} iconPath="/assets/historial_de_reembolsos_aprobados.png" link="/history?view=soi" id="check_budgets"/>
         )}
         {!isAdmin && authState.userPermissions.includes("check_budgets" as Permission) && (
           <Mosaic title={t('dashboard.refundsToRegister')} iconPath="/assets/reembolsos_por_aprobar.png" link="/check-refunds" id="check_refunds"/>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -3,7 +3,7 @@
  * Description: Renders the main dashboard page with a grid of mosaics linking to different sections of the application based on user permissions, and includes tutorial logic for first-time visitors.
  * Authors: Original Moncarca team
  * Last Modification made:
- * 06/05/2026 [Sergio Jiawei Xuan] Adjusted mosaic row gap to compensate for updated Mosaic wrapper padding.
+ * 19/05/2026 [Julio Rodriguez]: Hide travel history mosaic for admin users; use view_travel_agent_history for TA history mosaic; add notifications mosaic for company admins only.
  */
 
 import { useEffect } from "react";
@@ -50,7 +50,7 @@ export const Dashboard = ({title}:DashboardProps) => {
         {!isAdmin && authState.userPermissions.includes("create_request" as Permission) && (
           <Mosaic title={t('dashboard.createRequest')} iconPath="/assets/crear_solicitud_de_viaje.png" link="/requests/create" id="create-request"/>
         )}
-        {authState.userPermissions.includes("view_own_requests" as Permission) && (
+        {!isAdmin && authState.userPermissions.includes("view_own_requests" as Permission) && (
           <Mosaic title={t('dashboard.travelHistory')} iconPath="/assets/historial_de_viajes.png" link="/history" id="history"/>
         )}
         {!isAdmin && authState.userPermissions.includes("upload_vouchers" as Permission) && (
@@ -80,7 +80,7 @@ export const Dashboard = ({title}:DashboardProps) => {
         {/* {authState.userPermissions.includes("submit_reservations" as Permission) && (
           <Mosaic title="Formulario de ingreso de reservación" iconPath="/assets/formulario_de_ingreso_de_reservacion.png" link=""/>
         )} */}
-        {!isAdmin && authState.userPermissions.includes("view_assigned_requests_readonly" as Permission) && authState.userPermissions.includes("submit_reservations" as Permission) && (
+        {!isAdmin && authState.userPermissions.includes("view_travel_agent_history" as Permission) && (
           <Mosaic title={t('dashboard.reservedHistory')} iconPath="/assets/historial_de_viajes_reservados.png" link="/history" id="reserved_requests"/>
         )}
         {authState.isSystemAdmin && (
@@ -91,6 +91,9 @@ export const Dashboard = ({title}:DashboardProps) => {
         )}
         {authState.isCompanyAdmin && (
           <Mosaic title={t('dashboard.rules')} iconPath="/assets/historial_de_viajes.png" link="/admin/rules" id="rules"/>
+        )}
+        {authState.isCompanyAdmin && (
+          <Mosaic title={t('dashboard.notifications')} iconPath="/assets/crear_solicitud_de_viaje.png" link="/admin/notifications" id="notifications"/>
         )}
       </div>
     </Tutorial>

--- a/src/pages/Historial/Historial.tsx
+++ b/src/pages/Historial/Historial.tsx
@@ -4,7 +4,8 @@
  * It provides a customizable history page with travel records and related actions.
  * Authors: Original Moncarca team
  * Last Modification made:
- * 14/05/2026 [Diego de la Vega] Now travel agents see all requests except those in early stages
+ * 19/05/2026 [Julio Rodriguez] Route travel agents to dedicated /requests/ta-history endpoint;
+ *                              replace endpoint-string filters with permission-based filters.
  */
 
 import Table from "../../components/Refunds/Table";
@@ -110,19 +111,14 @@ export const Historial = () => {
             ? "/requests/to-approve-SOI"
             : authState.userPermissions.includes("view_approved_request_history" as Permission)
             ? "/requests/approved-history"
+            : authState.userPermissions.includes("view_travel_agent_history" as Permission)
+            ? "/requests/ta-history"
             : "/requests/all"
         let response = await getRequest(endpoint);
-        if (endpoint === "/requests/approved-history") {
+        if (authState.userPermissions.includes("view_approved_request_history" as Permission)) {
           response = response.filter((record: any) => !["Pending Review", "Denied", "Cancelled"].includes(record.status) && record.id_admin === authState.userId);
         }
-        if (endpoint === "/requests/all") {
-          const travelAgentsIds = response.flatMap((request: any) => (request.travel_agency?.users ?? []).map((user: any) => user.id));
-          // Travel agents see all requests except those in early stages (before they make reservations)
-          // Status shows only after reservations are completed (In Progress onwards)
-          response = response.filter((record: any) => !["Pending Review", "Denied", "Cancelled", "Changes Needed", "Pending Reservations"].includes(record.status) && travelAgentsIds.includes(authState.userId));
-
-        }
-        if (endpoint === "/requests/to-approve-SOI") {
+        if (authState.userPermissions.includes("check_budgets" as Permission)) {
           response = response.filter((record: any) => ["Pending Accounting Approval"].includes(record.status) && record.id_SOI === authState.userId);
         }
         // Data with actions (edit buttons)

--- a/src/pages/Historial/Historial.tsx
+++ b/src/pages/Historial/Historial.tsx
@@ -105,10 +105,12 @@ export const Historial = () => {
   useEffect(() => {
     const fetchTravelRecords = async () => {
       try {
-        const isApprovalsView = searchParams.get("view") === "approvals";
+        const view = searchParams.get("view");
         const endpoint =
-          isApprovalsView && authState.userPermissions.includes("view_approved_request_history" as Permission)
+          view === "approvals" && authState.userPermissions.includes("view_approved_request_history" as Permission)
             ? "/requests/approved-history"
+            : view === "soi" && authState.userPermissions.includes("check_budgets" as Permission)
+            ? "/requests/to-approve-SOI"
             : authState.userPermissions.includes("view_assigned_requests_readonly" as Permission) &&
               authState.userPermissions.includes("submit_reservations" as Permission)
             ? "/requests/reserved-history"
@@ -126,9 +128,7 @@ export const Historial = () => {
         if (endpoint === "/requests/reserved-history") {
           response = response.filter((record: any) => !["Pending Review", "Denied", "Cancelled", "Changes Needed", "Pending Reservations"].includes(record.status));
         }
-        if (endpoint === "/requests/to-approve-SOI") {
-          response = response.filter((record: any) => ["Pending Accounting Approval"].includes(record.status) && record.id_SOI === authState.userId);
-        }
+        // to-approve-SOI is already filtered by the backend (scoped to current SOI, status = Pending Accounting Approval)
         // Data with actions (edit buttons)
         setDataWithActions(response?.map((record: any, index: number) => {
           const sortedDestinations = [...(record.requests_destinations || [])].sort(
@@ -166,7 +166,7 @@ export const Historial = () => {
     };
 
     fetchTravelRecords();
-  }, []);
+  }, [searchParams]);
 
   useEffect(() => {
       // Get the visited pages from localStorage

--- a/src/pages/Historial/Historial.tsx
+++ b/src/pages/Historial/Historial.tsx
@@ -14,7 +14,7 @@ import { getRequest } from "../../utils/apiService";
 import formatDate from "../../utils/formatDate";
 import { Permission, useAuth } from "../../hooks/auth/authContext";
 import RefreshButton from "../../components/RefreshButton";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import Button from "../../components/Refunds/Button";
 import GoBack from "../../components/GoBack";
 import { Tutorial } from "../../components/Tutorial";
@@ -92,6 +92,7 @@ export const Historial = () => {
   const [dataWithActions, setDataWithActions] = useState([]);
   const { authState } = useAuth();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const { handleVisitPage, tutorial, setTutorial } = useApp();
   const { t } = useTranslation();
 
@@ -104,16 +105,19 @@ export const Historial = () => {
   useEffect(() => {
     const fetchTravelRecords = async () => {
       try {
+        const isApprovalsView = searchParams.get("view") === "approvals";
         const endpoint =
-          authState.userPermissions.includes("view_assigned_requests_readonly" as Permission) &&
-          authState.userPermissions.includes("submit_reservations" as Permission)
+          isApprovalsView && authState.userPermissions.includes("view_approved_request_history" as Permission)
+            ? "/requests/approved-history"
+            : authState.userPermissions.includes("view_assigned_requests_readonly" as Permission) &&
+              authState.userPermissions.includes("submit_reservations" as Permission)
             ? "/requests/reserved-history"
             : authState.userPermissions.includes("view_own_requests" as Permission)
             ? "/requests/user"
-            : authState.userPermissions.includes("check_budgets" as Permission)
-            ? "/requests/to-approve-SOI"
             : authState.userPermissions.includes("view_approved_request_history" as Permission)
             ? "/requests/approved-history"
+            : authState.userPermissions.includes("check_budgets" as Permission)
+            ? "/requests/to-approve-SOI"
             : authState.userPermissions.includes("view_travel_agent_history" as Permission)
             ? "/requests/ta-history"
             : "/requests/all"

--- a/src/pages/Historial/Historial.tsx
+++ b/src/pages/Historial/Historial.tsx
@@ -118,9 +118,7 @@ export const Historial = () => {
             ? "/requests/ta-history"
             : "/requests/all"
         let response = await getRequest(endpoint);
-        if (authState.userPermissions.includes("view_approved_request_history" as Permission)) {
-          response = response.filter((record: any) => !["Pending Review", "Denied", "Cancelled"].includes(record.status) && record.id_admin === authState.userId);
-        }
+        // approved-history is already filtered by the backend (scoped to current approver, excludes Pending Review/Denied/Cancelled)
         if (endpoint === "/requests/reserved-history") {
           response = response.filter((record: any) => !["Pending Review", "Denied", "Cancelled", "Changes Needed", "Pending Reservations"].includes(record.status));
         }

--- a/src/pages/Refunds/Vouchers.tsx
+++ b/src/pages/Refunds/Vouchers.tsx
@@ -65,6 +65,7 @@ export const Vouchers = () => {
   const { id } = useParams();
   const { t } = useTranslation();
   const [formData, setFormData] = useState<FormDataRow[]>([]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const [trip, setTrip] = useState<Trip>({
     id: 0,
     title: "",
@@ -103,6 +104,8 @@ export const Vouchers = () => {
       toast.error(t('vouchers.selectCurrencyError'));
       return;
     }
+    if (isSubmitting) return;
+    setIsSubmitting(true);
     try {
       let formDataToSend = null;
       for (const rowData of formData) {
@@ -112,7 +115,7 @@ export const Vouchers = () => {
           "id_request",
           trip.id.toString()
         );
-        formDataToSend.append("date", new Date().toISOString());
+        formDataToSend.append("date", rowData.date ? new Date(rowData.date).toISOString() : new Date().toISOString());
         formDataToSend.append("class", rowData.spentClass);
         formDataToSend.append("amount", rowData.amount.toString());
         formDataToSend.append("tax_type", rowData.taxIndicator);
@@ -137,9 +140,13 @@ export const Vouchers = () => {
         "Error sending refund request: ",
         err instanceof Error ? err.message : err
       );
-      toast.error(
-        t('vouchers.submitError')
-      );
+      const rawMsg = (err as { response?: { data?: { message?: unknown } } })?.response?.data?.message;
+      const apiMessage = typeof rawMsg === 'string' ? rawMsg
+        : Array.isArray(rawMsg) ? (rawMsg as string[]).join(', ')
+        : null;
+      toast.error(apiMessage ?? t('vouchers.submitError'));
+    } finally {
+      setIsSubmitting(false);
     }
   }; 
 
@@ -502,12 +509,13 @@ export const Vouchers = () => {
             </Link>
             <button
               id="submit-refund"
-              className="px-4 py-2 bg-[#0a2c6d] text-white rounded-md hover:bg-[#0d3d94] transition-colors hover:cursor-pointer"
+              disabled={isSubmitting}
+              className={`px-4 py-2 text-white rounded-md transition-colors ${isSubmitting ? "bg-gray-400 cursor-not-allowed" : "bg-[#0a2c6d] hover:bg-[#0d3d94] hover:cursor-pointer"}`}
               onClick={() => {
                 handleSubmitRefund();
               }}
             >
-              {t('vouchers.submit')}
+              {isSubmitting ? t('common.loading') : t('vouchers.submit')}
             </button>
           </div>
         </div>

--- a/src/pages/RequestInfo.tsx
+++ b/src/pages/RequestInfo.tsx
@@ -4,6 +4,8 @@
  * Authors: Original Moncarca team
  * Last Modification made:
  * 14/05/2026 [Diego de la Vega] Update destinations display to show origin-to-destination flow and synthesize return legs. Added dark mode for some buttons.
+ * 19/05/2026 [Julio Rodriguez] Disabled submit buttons while request is in-flight (isSubmitting).
+ *                              Show folio (YYYY-NNN) in header badge instead of UUID.
  */
 
 import React, { useState, useEffect } from 'react';
@@ -100,6 +102,7 @@ const RequestInfo: React.FC = () => {
   const prevRefRes = React.useRef(null);
   const nextRefRes = React.useRef(null);
 
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const { handleVisitPage, tutorial } = useApp();
   const { t } = useTranslation();
 
@@ -204,6 +207,7 @@ const RequestInfo: React.FC = () => {
           requests_destinations: mappedDests,
           effective_advance_money: effectiveAdvanceMoney,
           reservations: reservations,
+          createdYear: new Date(response.createdAt).getFullYear(),
           createdAt: formatDate(response.createdAt),
           advance_money_str: formatMoney(
             normalizedAdvanceMoney ?? effectiveAdvanceMoney,
@@ -356,6 +360,8 @@ const RequestInfo: React.FC = () => {
       });
       return;
     }
+    if (isSubmitting) return;
+    setIsSubmitting(true);
     try {
       await patchRequest(`/requests/approve/${id}`, {
         id_travel_agency: selectedAgency,
@@ -372,7 +378,8 @@ const RequestInfo: React.FC = () => {
         position: 'top-right',
         autoClose: 3000,
       });
-      return;
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -391,6 +398,8 @@ const RequestInfo: React.FC = () => {
       });
       return;
     }
+    if (isSubmitting) return;
+    setIsSubmitting(true);
     try {
       await postRequest(`/revisions`, {
         id_request: id,
@@ -408,7 +417,8 @@ const RequestInfo: React.FC = () => {
         position: 'top-right',
         autoClose: 3000,
       });
-      return;
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -420,6 +430,8 @@ const RequestInfo: React.FC = () => {
    * Returns: Promise<void> - Sends deny request and redirects on success.
    */
   const deny = async () => {
+    if (isSubmitting) return;
+    setIsSubmitting(true);
     try {
       await patchRequest(`/requests/deny/${id}`, {});
       clearRequestInfoDraft();
@@ -434,7 +446,8 @@ const RequestInfo: React.FC = () => {
         position: 'top-right',
         autoClose: 3000,
       });
-      return;
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -446,6 +459,8 @@ const RequestInfo: React.FC = () => {
    * Returns: Promise<void> - Sends cancel request and redirects on success.
    */
   const cancel = async () => {
+    if (isSubmitting) return;
+    setIsSubmitting(true);
     try {
       await patchRequest(`/requests/cancel/${id}`, {});
       clearRequestInfoDraft();
@@ -460,7 +475,8 @@ const RequestInfo: React.FC = () => {
         position: 'top-right',
         autoClose: 3000,
       });
-      return;
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -472,6 +488,8 @@ const RequestInfo: React.FC = () => {
    * Returns: Promise<void> - Sends status update and redirects on success.
    */
   const register = async () => {
+    if (isSubmitting) return;
+    setIsSubmitting(true);
     try {
       await patchRequest(`/requests/SOI-approve/${id}`, {});
       clearRequestInfoDraft();
@@ -486,7 +504,8 @@ const RequestInfo: React.FC = () => {
         position: 'top-right',
         autoClose: 3000,
       });
-      return;
+    } finally {
+      setIsSubmitting(false);
     }
   }
 
@@ -496,6 +515,8 @@ const RequestInfo: React.FC = () => {
    * Returns: Promise<void> - Sends completion request and redirects on success.
    */
   const complete = async () => {
+    if (isSubmitting) return;
+    setIsSubmitting(true);
     try {
       await patchRequest(`/requests/complete-request/${id}`, {});
       clearRequestInfoDraft();
@@ -510,7 +531,8 @@ const RequestInfo: React.FC = () => {
         position: 'top-right',
         autoClose: 3000,
       });
-      return;
+    } finally {
+      setIsSubmitting(false);
     }
   }
 
@@ -524,6 +546,11 @@ const RequestInfo: React.FC = () => {
     }, 0) ?? 0;
   const previewBalance = previewAdvanceMoney - approvedVoucherTotal;
 
+  const folio =
+    data?.request_num && data?.createdYear
+      ? `${data.createdYear}-${String(data.request_num).padStart(3, '0')}`
+      : null;
+
   return ( // Returns the main JSX content of the RequestInfo page, including request details, destinations, reservations, vouchers, and action buttons based on user permissions and request status.
     <Tutorial page="requestInfo" run={tutorial}>
       <div className="pb-10">
@@ -531,7 +558,7 @@ const RequestInfo: React.FC = () => {
         <main className="max-w-6xl bg-[var(--color-card-bg)] mx-auto rounded-lg shadow-lg overflow-hidden">
           <div className="px-8 py-10 flex flex-col">
             <div className="w-fit bg-[var(--blue)] text-white text-xs lg:text-base px-4 py-2 rounded-full mb-6">
-              {t('requestInfo.title')} <span>{id}</span>
+              {t('requestInfo.title')} <span>{folio ?? id}</span>
             </div>
             <p className="mb-6 text-gray-700 font-medium">
               {t('requestInfo.requester')} <span className="text-[var(--color-page-text-title)]">{data?.user?.name} {data?.user?.last_name}</span>
@@ -925,40 +952,39 @@ const RequestInfo: React.FC = () => {
                 <footer className="flex flex-col sm:flex-row gap-4">
                   <button
                     onClick={approve}
-                    disabled={!selectedAgency || data.status !== "Pending Review"}
+                    disabled={isSubmitting || !selectedAgency || data.status !== "Pending Review"}
                     className={`flex-1 py-3 rounded-lg font-semibold transition
-                    ${selectedAgency && data.status === "Pending Review"
+                    ${!isSubmitting && selectedAgency && data.status === "Pending Review"
                         ? 'bg-green-600 hover:bg-green-700 text-white'
                         : 'bg-gray-300 text-gray-500 cursor-not-allowed'
                       }`}
                     id="approve-request-button"
                   >
-                    {t('requestInfo.approve')}
+                    {isSubmitting ? t('common.loading') : t('requestInfo.approve')}
                   </button>
                   <button
                     onClick={requestChanges}
-                    disabled={!comment.trim() || data.status !== "Pending Review"}
+                    disabled={isSubmitting || !comment.trim() || data.status !== "Pending Review"}
                     className={`flex-1 py-3 rounded-lg font-semibold transition
-                    ${comment.trim() && data.status === "Pending Review"
+                    ${!isSubmitting && comment.trim() && data.status === "Pending Review"
                         ? 'bg-yellow-500 hover:bg-yellow-600 text-white'
                         : 'bg-gray-300 text-gray-500 cursor-not-allowed'
                       }`}
-
                     id="changes-request-button"
                   >
-                    {t('requestInfo.requestChanges')}
+                    {isSubmitting ? t('common.loading') : t('requestInfo.requestChanges')}
                   </button>
                   <button
                     onClick={deny}
-                    disabled={data.status !== "Pending Review"}
+                    disabled={isSubmitting || data.status !== "Pending Review"}
                     className={`flex-1 py-3 rounded-lg font-semibold transition
-                    ${data.status === "Pending Review"
+                    ${!isSubmitting && data.status === "Pending Review"
                         ? 'bg-red-600 hover:bg-red-700 text-white'
                         : 'bg-gray-300 text-gray-500 cursor-not-allowed'
                       }`}
                     id="deny-request-button"
                   >
-                    {t('requestInfo.deny')}
+                    {isSubmitting ? t('common.loading') : t('requestInfo.deny')}
                   </button>
                 </footer>
               </>
@@ -979,14 +1005,14 @@ const RequestInfo: React.FC = () => {
                 </button>
                 <button
                   onClick={cancel}
-                  disabled={data.status !== "Pending Review" && data.status !== "Changes Needed"}
-                  className={`flex-1 py-3 rounded-lg font-semibold transition ${data.status !== "Pending Review" && data.status !== "Changes Needed"
-                      ? "bg-gray-300 text-gray-500 cursor-not-allowed"
-                      : "bg-red-600 hover:bg-red-700 text-white"
+                  disabled={isSubmitting || (data.status !== "Pending Review" && data.status !== "Changes Needed")}
+                  className={`flex-1 py-3 rounded-lg font-semibold transition ${!isSubmitting && (data.status === "Pending Review" || data.status === "Changes Needed")
+                      ? "bg-red-600 hover:bg-red-700 text-white"
+                      : "bg-gray-300 text-gray-500 cursor-not-allowed"
                     }`}
                   id="cancel-request-button"
                 >
-                  {t('requestInfo.cancel')}
+                  {isSubmitting ? t('common.loading') : t('requestInfo.cancel')}
                 </button>
 
               </footer>}
@@ -996,13 +1022,13 @@ const RequestInfo: React.FC = () => {
                 <button
                   id="register-spend"
                   onClick={register}
-                  disabled={data.status !== "Pending Accounting Approval"}
-                  className={`flex-1 py-3 rounded-lg font-semibold transition ${data.status === "Pending Accounting Approval"
+                  disabled={isSubmitting || data.status !== "Pending Accounting Approval"}
+                  className={`flex-1 py-3 rounded-lg font-semibold transition ${!isSubmitting && data.status === "Pending Accounting Approval"
                       ? 'bg-blue-600 hover:bg-blue-700 text-white'
                       : 'bg-gray-300 text-gray-500 cursor-not-allowed'
                     }`}
                 >
-                  {t('requestInfo.markAsRegistered')}
+                  {isSubmitting ? t('common.loading') : t('requestInfo.markAsRegistered')}
                 </button>
               </footer>
             }
@@ -1012,13 +1038,13 @@ const RequestInfo: React.FC = () => {
                 <button
                   id="complete-refund-request"
                   onClick={complete}
-                  disabled={data.status !== "Pending Refund Approval"}
-                  className={`flex-1 py-3 rounded-lg font-semibold transition ${data.status === "Pending Refund Approval"
+                  disabled={isSubmitting || data.status !== "Pending Refund Approval"}
+                  className={`flex-1 py-3 rounded-lg font-semibold transition ${!isSubmitting && data.status === "Pending Refund Approval"
                       ? 'bg-blue-600 hover:bg-blue-700 text-white'
                       : 'bg-gray-300 text-gray-500 cursor-not-allowed'
                     }`}
                 >
-                  {t('requestInfo.markAsCompleted')}
+                  {isSubmitting ? t('common.loading') : t('requestInfo.markAsCompleted')}
                 </button>
               </footer>
             }

--- a/src/pages/Reservations/Reservations.tsx
+++ b/src/pages/Reservations/Reservations.tsx
@@ -40,6 +40,7 @@ export const Reservations = () => {
   const [formData, setFormData] = useState<Record<string, any>>({});
   const [request, setRequest] = useState<any>({});
   const [isFormValid, _setIsFormValid] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const { handleVisitPage, tutorial } = useApp();
   const { t } = useTranslation();
   const [activePreview, setActivePreview] = useState<string | null>(null);
@@ -383,6 +384,8 @@ export const Reservations = () => {
       toast.error(t('reservations.fillRequired'));
       return;
     }
+    if (isSubmitting) return;
+    setIsSubmitting(true);
     // Format the formData to match the API requirements
     const formattedData = {
       reservations: Object.entries(formData).flatMap(([key, value]) => {
@@ -480,6 +483,8 @@ export const Reservations = () => {
     } catch (error) {
       console.error("Error sending data:", error);
       toast.error(t('reservations.sendError'));
+    } finally {
+      setIsSubmitting(false);
     }
   }
 
@@ -835,12 +840,13 @@ export const Reservations = () => {
               <button
                 type="submit"
                 id="assign-reservations"
-                className={`px-4 py-2 rounded-md transition-colors ${isFormValid
+                disabled={isSubmitting}
+                className={`px-4 py-2 rounded-md transition-colors ${!isSubmitting && isFormValid
                     ? "bg-[#0a2c6d] text-white hover:bg-[#0d3d94]"
                     : "bg-gray-400 text-white cursor-not-allowed"
                   }`}
               >
-                {t('reservations.submit')}
+                {isSubmitting ? t('common.loading') : t('reservations.submit')}
               </button>
             </div>
           </form>


### PR DESCRIPTION
## Description

Displays the request folio (YYYY-NNN) in the request detail view, adds a double-submit guard across request creation and voucher upload flows, fixes the voucher date field being ignored in favor of today's date, improves API error messages in toasts, adds a company admin UI to configure the per-company voucher submission deadline, and adds an accounting export page for SOI users to generate SAP FI poliza JSON files.

**Changes included:**
- `RequestInfo.tsx` — displays folio `YYYY-NNN` badge; adds `isSubmitting` guard on submit button
- `Reservations.tsx` — adds `isSubmitting` guard to prevent duplicate reservation submissions
- `Vouchers.tsx` — adds `isSubmitting` guard; fixes voucher date using `rowData.date` instead of always sending today; shows actual API error message in toast instead of generic fallback
- `AdminUsers.tsx` — shows company name instead of raw UUID in users table
- `AdminRules.tsx` — adds voucher deadline configuration section (`PATCH /admin/companies/:companyId/settings`); replaces hardcoded Spanish strings with i18n keys; unifies CECO display to show id + name
- `AccountingExport.tsx` — new page for SOI users to list completed trips and download poliza JSON per trip
- `Sidebar.tsx` — adds "Notifications" link for company admins; adds "Exportar pólizas contables" link for SOI users
- `Dashboard.tsx` — adds accounting export mosaic tile for users with `check_budgets` permission
- `es.json` / `en.json` — adds i18n keys for voucher deadline section and accounting module

## How to test

**Prerequisites:** Run the backend with migrations v1–v6 applied (`npm run db:drop && npm run migration:run && npm run db:seed`). All seed users use password `password`.

**1. Request folio display**
- Log in as `requester1@monarca.com` and create a travel request.
- Open the request detail view — verify a `YYYY-NNN` badge is visible in the header.

**2. Double-submit guard**
- On the request creation form, click Submit twice quickly — only one request should be created.
- On the voucher upload form, click Submit twice quickly — only one upload should fire.

**3. Voucher date fix**
- Log in as `requester1@monarca.com`, open a request in `COMPROBACION` status, and upload a voucher with a specific past date.
- Verify the saved voucher shows the date you entered, not today's date.

**4. Voucher deadline configuration**
- Log in as `admin@monarcamx.com` → Admin → Rules.
- Change the voucher submission deadline to a different value and save.
- Verify the toast confirms success and the value persists on reload.

**5. Accounting export (SOI)**
- Log in as `soi1@monarcamx.com`.
- Verify the sidebar shows "Exportar pólizas contables" and the Dashboard shows an accounting tile.
- Navigate to `/accounting/export` — verify the table lists completed trips.
- Click "Generar" on any row — verify a `poliza_YYYY-NNN.json` file downloads.

## PR Targeting Checklist

- [x] This PR targets the `develop` branch (for most changes)
- [ ] This PR targets the `main` branch (ONLY for release branches or hotfixes)

> ⚠️ IMPORTANT: PRs to `main` should only come from `develop` or release branches.
> If this is a feature or bugfix PR, please retarget to `develop`.

Closes #38 