### PR TITLE
fix(form): fix cross-user draft recovery and false restore toast

### DIFF
--- a/src/components/travel-requests/TravelRequestForm.tsx
+++ b/src/components/travel-requests/TravelRequestForm.tsx
@@ -342,7 +342,7 @@ function TravelRequestForm({ initialData, requestId }: TravelRequestFormProps) {
     control,
     register,
     handleSubmit,
-    formState: { errors },
+    formState: { errors, isDirty },
     reset,
     trigger,
   } = useForm<FormValues, unknown, SubmitValues>({
@@ -384,6 +384,7 @@ function TravelRequestForm({ initialData, requestId }: TravelRequestFormProps) {
     control,
     reset,
     enabled: !isEditing,
+    isDirty,
   });
 
   const { fields, append, remove } = useFieldArray({

--- a/src/components/travel-requests/TravelRequestForm.tsx
+++ b/src/components/travel-requests/TravelRequestForm.tsx
@@ -38,6 +38,7 @@ import GoBack from "../GoBack";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { makeCurrencyOptions } from "../../utils/currencies";
 import { usePersistedForm } from "../../hooks/app/usePersistedForm";
+import { useAuth } from "../../hooks/auth/authContext";
 
 type Option = { id: number | string; name: string };
 
@@ -266,6 +267,7 @@ function DestinationFields({
 function TravelRequestForm({ initialData, requestId }: TravelRequestFormProps) {
   const navigate = useNavigate();
   const { t, i18n } = useTranslation();
+  const { authState } = useAuth();
 
   const tRef = useRef(t);
   tRef.current = t;
@@ -375,7 +377,7 @@ function TravelRequestForm({ initialData, requestId }: TravelRequestFormProps) {
   const persistStorageKey =
     isEditing && requestId
       ? `travelRequestForm:edit:${requestId}`
-      : "travelRequestForm:create";
+      : `travelRequestForm:create:${authState.userId}`;
 
   const { clearPersistedForm } = usePersistedForm<FormValues, SubmitValues>({
     storageKey: persistStorageKey,

--- a/src/hooks/app/usePersistedForm.ts
+++ b/src/hooks/app/usePersistedForm.ts
@@ -17,6 +17,7 @@ interface UsePersistedFormParams<
   control: Control<T, unknown, TTransformedValues>;
   reset: UseFormReset<T>;
   enabled?: boolean;
+  isDirty?: boolean;
 }
 
 /**
@@ -36,6 +37,7 @@ export function usePersistedForm<
   control,
   reset,
   enabled = true,
+  isDirty = false,
 }: UsePersistedFormParams<T, TTransformedValues>) {
   const values = useWatch({ control });
   const isHydratedRef = useRef(false);
@@ -84,6 +86,10 @@ export function usePersistedForm<
       return;
     }
 
+    if (!isDirty) {
+      return;
+    }
+
     try {
       window.localStorage.setItem(storageKey, JSON.stringify(values));
     } catch {
@@ -92,7 +98,7 @@ export function usePersistedForm<
       });
       // Ignore quota and serialization errors to avoid blocking form usage.
     }
-  }, [enabled, saveErrorToastId, storageKey, values]);
+  }, [enabled, isDirty, saveErrorToastId, storageKey, values]);
 
   const clearPersistedForm = () => {
     if (typeof window === "undefined") {


### PR DESCRIPTION
## Summary
- Scope draft localStorage key by userId to prevent cross-user recovery.
- Gate persistence on `isDirty` to avoid saving empty form state and
  triggering a false restore toast.

## Test plan
- [ ] Two users on same browser should not share draft data.
- [ ] Empty form visit should not trigger restore toast.
- [ ] Partially filled form should restore correctly on return.