### PR TITLE
fix: UI improvements, admin rules fixes, and refund downloads

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -135,6 +135,22 @@ a {
   color: var(--color-page-text);
 }
 
+.dark input[type="date"],
+.dark input[type="datetime-local"],
+.dark input[type="time"],
+.dark input[type="month"],
+.dark input[type="week"] {
+  color-scheme: dark;
+}
+
+.dark input[type="date"]::-webkit-calendar-picker-indicator,
+.dark input[type="datetime-local"]::-webkit-calendar-picker-indicator,
+.dark input[type="time"]::-webkit-calendar-picker-indicator,
+.dark input[type="month"]::-webkit-calendar-picker-indicator,
+.dark input[type="week"]::-webkit-calendar-picker-indicator {
+  filter: invert(0.6);
+}
+
 .dark {
   --color-page-bg: #121212;
   --color-page-text: #f9fafb;

--- a/src/components/Refunds/FilePreviewer.tsx
+++ b/src/components/Refunds/FilePreviewer.tsx
@@ -85,22 +85,42 @@ const FilePreviewer = ({ file, fileIndex, showDownload = true }: FilePreviewerPr
               {showDownload && (
                 <div className="mt-4 flex justify-between items-center">
                   <div className="flex space-x-4">
-                    <a
+                    <button
                       id={`download-file-xml-${fileIndex}`}
-                      href={file.file_url_xml}
-                      download={`comprobante${fileIndex + 1}.xml`}
+                      onClick={async () => {
+                        const response = await fetch(file.file_url_xml);
+                        const blob = await response.blob();
+                        const url = window.URL.createObjectURL(blob);
+                        const link = document.createElement("a");
+                        link.href = url;
+                        link.download = `comprobante${fileIndex + 1}.xml`;
+                        document.body.appendChild(link);
+                        link.click();
+                        link.remove();
+                        window.URL.revokeObjectURL(url);
+                      }}
                       className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 hover:cursor-pointer"
                     >
                       {t('refundAcceptance.downloadXml')}
-                    </a>
-                    <a
+                    </button>
+                    <button
                       id={`download-file-pdf-${fileIndex}`}
-                      href={file.file_url_pdf}
-                      download={`comprobante${fileIndex + 1}.pdf`}
+                      onClick={async () => {
+                        const response = await fetch(file.file_url_pdf);
+                        const blob = await response.blob();
+                        const url = window.URL.createObjectURL(blob);
+                        const link = document.createElement("a");
+                        link.href = url;
+                        link.download = `comprobante${fileIndex + 1}.pdf`;
+                        document.body.appendChild(link);
+                        link.click();
+                        link.remove();
+                        window.URL.revokeObjectURL(url);
+                      }}
                       className="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 hover:cursor-pointer"
                     >
                       {t('refundAcceptance.downloadPdf')}
-                    </a>
+                    </button>
                   </div>
                 </div>
               )}

--- a/src/components/Refunds/InputField.tsx
+++ b/src/components/Refunds/InputField.tsx
@@ -360,6 +360,7 @@ const InputField: React.FC<InputFieldProps> = ({
             aria-invalid={!!errorMessage}
             aria-required={required}
             role={type === "date" ? "spinbutton" : undefined}
+            style={type === "date" && !value ? { color: '#9ca3af' } : undefined}
           />
         </div>
       </>

--- a/src/components/travel-requests/TravelRequestForm.tsx
+++ b/src/components/travel-requests/TravelRequestForm.tsx
@@ -352,7 +352,7 @@ function TravelRequestForm({ initialData, requestId }: TravelRequestFormProps) {
       motive: "",
       title: "",
       priority: "media",
-      advance_money: "0.00",
+      advance_money: "",
       currency: "",
       requirements: "",
       return_date: "",

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -29,16 +29,20 @@ export type InputProps = React.InputHTMLAttributes<HTMLInputElement> & {
  * Output: JSX.Element - An <input> element with merged classes and forwarded props.
  */
 export const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, onWheel, onFocus, onBlur, type, ...props }, ref) => {
+  ({ className, onWheel, onFocus, onBlur, type, value, style, ...props }, ref) => {
     /**
      * baseStyles, provides default Tailwind/CSS classes for consistent input appearance across the UI.
      */
     const baseStyles =
       "bg-[var(--color-card-bg)] border border-[var(--color-border)] text-[var(--color-page-text)] text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5";
+    const dateStyle: React.CSSProperties | undefined =
+      type === "date" && !value ? { color: "#9ca3af", ...style } : style;
     return (
       <input
         ref={ref}
         type={type}
+        value={value}
+        style={dateStyle}
         className={clsx(baseStyles, className)}
         onFocus={(e) => {
           if (type === "number") {

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -50,16 +50,22 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
               _wheelHandler?: (event: WheelEvent) => void;
             };
 
+            const nativeSetter = Object.getOwnPropertyDescriptor(
+              window.HTMLInputElement.prototype,
+              "value"
+            )?.set;
+
             const handleWheel = (event: WheelEvent) => {
               event.preventDefault();
               const current = parseFloat(el.value || "0");
+              const step = parseFloat(el.step) || 1;
+              const next =
+                event.deltaY < 0 ? current + step : Math.max(0, current - step);
+              const formatted = Number.isInteger(step)
+                ? String(Math.round(next))
+                : next.toFixed(2);
 
-              if (event.deltaY < 0) {
-                el.value = (current + 1).toFixed(2);
-              } else {
-                el.value = Math.max(0, current - 1).toFixed(2);
-              }
-
+              nativeSetter?.call(el, formatted);
               el.dispatchEvent(new Event("input", { bubbles: true }));
             };
 

--- a/src/pages/Admin/AdminRules.tsx
+++ b/src/pages/Admin/AdminRules.tsx
@@ -396,7 +396,8 @@ export default function AdminRules() {
   const handleSaveDeadline = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!companyId) return;
-    const days = parseInt(deadlineInput, 10);
+    const inputEl = (e.currentTarget.elements.namedItem("voucher_deadline_days")) as HTMLInputElement | null;
+    const days = parseInt(inputEl?.value ?? deadlineInput, 10);
     if (isNaN(days) || days < 1) return;
     setSavingDeadline(true);
     setMessage(null);
@@ -435,25 +436,27 @@ export default function AdminRules() {
           <p className="text-sm text-gray-600">
             {companyId ? `${t('admin.notifications.activeCompany')} ${companyName ?? companyId}` : t('admin.notifications.companyUnavailable')}
           </p>
-          <div className="flex items-center gap-3">
+          <div className="flex items-center justify-between w-full lg:w-auto gap-3">
             <select
               value={filterActive}
               onChange={(e) => { setFilterActive(e.target.value as 'all' | 'active' | 'inactive'); setCurrentPage(1); }}
-              className={selectClass}
+              className="bg-[var(--color-card-bg)] border border-[var(--color-border)] text-gray-500 text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 p-2.5 min-w-[90px]"
             >
               <option value="all">{t('admin.rules.all')}</option>
               <option value="active">{t('admin.rules.active')}</option>
               <option value="inactive">{t('admin.rules.inactive')}</option>
             </select>
-            <button
-              id="btn_newRule"
-              onClick={() => { setShowForm(!showForm); setMessage(null); }}
-              disabled={!canLoad}
-              className="px-4 py-2 bg-[#0a2c6d] text-white text-sm rounded-md cursor-pointer hover:bg-[#0d3d94] transition-colors disabled:opacity-50"
-            >
-              {showForm ? t('common.cancel') : t('admin.rules.createRule')}
-            </button>
-            <RefreshButton />
+            <div className="flex items-center gap-3 shrink-0">
+              <button
+                id="btn_newRule"
+                onClick={() => { setShowForm(!showForm); setMessage(null); }}
+                disabled={!canLoad}
+                className="px-4 py-2 bg-[#0a2c6d] text-white text-sm rounded-md cursor-pointer hover:bg-[#0d3d94] transition-colors disabled:opacity-50 whitespace-nowrap"
+              >
+                {showForm ? t('common.cancel') : t('admin.rules.createRule')}
+              </button>
+              <RefreshButton />
+            </div>
           </div>
         </div>
 

--- a/src/pages/Refunds/RefundsAcceptance.tsx
+++ b/src/pages/Refunds/RefundsAcceptance.tsx
@@ -335,20 +335,44 @@ const RefundsAcceptance: React.FC = () => {
                     {t('refundAcceptance.previous')}
                   </button>
                   <div className="flex flex-wrap gap-3">
-                    <a
-                      href={data?.vouchers?.[currentIndex]?.file_url_xml}
-                      download={`comprobante${currentIndex + 1}.xml`}
-                      className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
+                    <button
+                      onClick={async () => {
+                        const url = data?.vouchers?.[currentIndex]?.file_url_xml;
+                        if (!url) return;
+                        const response = await fetch(url);
+                        const blob = await response.blob();
+                        const objUrl = window.URL.createObjectURL(blob);
+                        const link = document.createElement("a");
+                        link.href = objUrl;
+                        link.download = `comprobante${currentIndex + 1}.xml`;
+                        document.body.appendChild(link);
+                        link.click();
+                        link.remove();
+                        window.URL.revokeObjectURL(objUrl);
+                      }}
+                      className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 cursor-pointer"
                     >
                       {t('refundAcceptance.downloadXml')}
-                    </a>
-                    <a
-                      href={data?.vouchers?.[currentIndex]?.file_url_pdf}
-                      download={`comprobante${currentIndex + 1}.pdf`}
-                      className="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700"
+                    </button>
+                    <button
+                      onClick={async () => {
+                        const url = data?.vouchers?.[currentIndex]?.file_url_pdf;
+                        if (!url) return;
+                        const response = await fetch(url);
+                        const blob = await response.blob();
+                        const objUrl = window.URL.createObjectURL(blob);
+                        const link = document.createElement("a");
+                        link.href = objUrl;
+                        link.download = `comprobante${currentIndex + 1}.pdf`;
+                        document.body.appendChild(link);
+                        link.click();
+                        link.remove();
+                        window.URL.revokeObjectURL(objUrl);
+                      }}
+                      className="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 cursor-pointer"
                     >
                       {t('refundAcceptance.downloadPdf')}
-                    </a>
+                    </button>
                     <button
                       disabled={data?.vouchers?.[currentIndex]?.status !== "pending_voucher"}
                       className={`px-4 py-2 text-white rounded-md hover:cursor-pointer ${data?.vouchers?.[currentIndex]?.status !== "pending_voucher"

--- a/src/pages/RequestInfo.tsx
+++ b/src/pages/RequestInfo.tsx
@@ -337,7 +337,6 @@ const RequestInfo: React.FC = () => {
     { key: 'id_origin_city', label: t('requestInfo.labelOriginCity') },
     { key: 'destinations', label: t('requestInfo.labelDestinations') },
     { key: 'motive', label: t('requestInfo.labelMotive') },
-    { key: 'currency', label: t('requestInfo.labelCurrency') },
     { key: 'unconverted_advance_money_str', label: t('requestInfo.labelAdvanceOrigin') },
     { key: 'exchange_rate_str', label: t('requestInfo.labelExchangeRate') },
     { key: 'advance_money_str', label: t('requestInfo.labelAdvanceMXN') },


### PR DESCRIPTION
## Summary
- Remove duplicate currency field from request detail view (amount already includes currency)
- Fix date input styling in dark mode: gray format text when empty, white when filled, dark calendar picker dropdown
- Fix Admin Rules header layout on mobile: filter select left, create/refresh buttons right; fix wheel input handling and deadline save stale closure
- Use blob download for PDF/XML buttons in refunds to prevent page redirect

## Test plan
- [ ] Request detail view: Moneda field should no longer appear separately
- [ ] Dark mode: date inputs show gray mm/dd/yyyy when empty, white when a date is selected; calendar picker dropdown is dark
- [ ] Admin Rules: on mobile the Todos select is left-aligned and Create/Refresh are right-aligned; deadline days saves correctly via wheel or typing
- [ ] Refunds acceptance: clicking Download PDF or XML downloads directly without redirecting or opening a new tab