### PR TITLE
feat(audit-logs): add audit log page, company requests view, and i18n translations

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -4,7 +4,7 @@
  *              and permission-based navigation links using SidebarOption items.
  * Authors: Original Moncarca team
  * Last Modification made:
- * 19/05/2026 [Julio Rodriguez]: Hide travel history link for admin users; use view_travel_agent_history for TA history link; fix duplicated label for travel agents.
+ * 21/05/2026 [Julio Rodriguez]: Added audit logs link for company admins.
  */
 
 // ***************** images *****************
@@ -98,6 +98,12 @@ function Sidebar({ user, onNavigate }: { user: AuthState, onNavigate?: () => voi
             )}
             {user.isCompanyAdmin && (
               <SidebarOption label={t('sidebar.notifications')} pathIcon="/assets/crear_solicitud_de_viaje.png" link="/admin/notifications" onClick={onNavigate}/>
+            )}
+            {user.isCompanyAdmin && (
+              <SidebarOption label={t('sidebar.auditLogs')} pathIcon="/assets/historial_de_viajes.png" link="/admin/audit-logs" onClick={onNavigate}/>
+            )}
+            {user.isCompanyAdmin && (
+              <SidebarOption label={t('sidebar.companyRequests')} pathIcon="/assets/historial_de_viajes.png" link="/admin/company-requests" onClick={onNavigate}/>
             )}
         </ul>
         <div className="flex gap-7 items-center p-2 mt-10">

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -703,7 +703,8 @@
         "REQUEST_CANCELLED": "Request cancelled — Folio {{folio}}: \"{{title}}\"",
         "RULE_CREATED": "Approval rule created: \"{{name}}\" (order {{order}})",
         "RULE_UPDATED": "Approval rule updated: \"{{name}}\" — fields: {{fields}}",
-        "FIRST_LOGIN": "First login: {{email}}"
+        "FIRST_LOGIN": "First login: {{email}}",
+        "USERS_IMPORTED": "User import: {{created}} created, {{updated}} updated, {{unchanged}} unchanged, {{errors}} error(s)"
       },
       "fieldNames": {
         "is_requester": "Requester",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -15,7 +15,9 @@
     "rules": "Rules",
     "notifications": "Notifications",
     "reservedHistory": "Reserved travel history",
-    "accountingExport": "Export accounting polizas"
+    "accountingExport": "Export accounting polizas",
+    "auditLogs": "Audit log",
+    "companyRequests": "Requests"
   },
   "dashboard": {
     "createRequest": "Create travel request",
@@ -32,7 +34,9 @@
     "newCompany": "New company",
     "userList": "User list",
     "rules": "Rules",
-    "notifications": "Notifications"
+    "notifications": "Notifications",
+    "auditLogs": "Audit log",
+    "companyRequests": "Requests"
   },
   "header": {
     "logout": "Log out"
@@ -667,6 +671,65 @@
       "reservationsDesc": "Notifies by email when a reservation is created.",
       "adminAlerts": "Administrative alerts",
       "adminAlertsDesc": "Notifies by email about relevant administrative events."
+    },
+    "companyRequests": {
+      "title": "Company requests",
+      "folio": "Folio",
+      "title_col": "Title",
+      "requester": "Requester",
+      "status": "Status",
+      "createdAt": "Date",
+      "actions": "Actions",
+      "view": "View request",
+      "errorLoading": "Error loading requests."
+    },
+    "auditLogs": {
+      "title": "Audit log",
+      "date": "Date",
+      "user": "Affected user",
+      "email": "Email",
+      "action": "Action",
+      "seeMore": "see more",
+      "seeLess": "see less",
+      "viewRequest": "View request",
+      "errorLoading": "Error loading audit log.",
+      "actions": {
+        "USER_CREATED": "User created: {{email}} (roles: {{flags}})",
+        "USER_PROFILE_UPDATED": "Profile updated for {{email}} — fields: {{fields}}",
+        "USER_FLAGS_UPDATED": "Roles updated for {{email}}: {{flags}}",
+        "USER_DELETED": "User deleted: {{email}}",
+        "SETTINGS_UPDATED": "Company settings updated: {{fields}}",
+        "REQUEST_CREATED": "Request created — Folio {{folio}}: \"{{title}}\"",
+        "REQUEST_CANCELLED": "Request cancelled — Folio {{folio}}: \"{{title}}\"",
+        "RULE_CREATED": "Approval rule created: \"{{name}}\" (order {{order}})",
+        "RULE_UPDATED": "Approval rule updated: \"{{name}}\" — fields: {{fields}}",
+        "FIRST_LOGIN": "First login: {{email}}"
+      },
+      "fieldNames": {
+        "is_requester": "Requester",
+        "is_approver": "Approver",
+        "is_soi": "SOI",
+        "is_travelAgent": "Travel Agent",
+        "is_company_admin": "Company Admin",
+        "voucher_deadline_days": "Voucher deadline (days)",
+        "name": "Name",
+        "last_name": "Last name",
+        "email": "Email",
+        "employee_num": "Employee no.",
+        "status": "Status",
+        "password": "Password",
+        "user_name": "Username",
+        "level_order": "Order",
+        "is_active": "Active",
+        "description": "Description",
+        "code": "Code",
+        "applies_to": "Applies to",
+        "min_amount": "Min. amount",
+        "max_amount": "Max. amount",
+        "required_approvals": "Required approvals"
+      },
+      "boolTrue": "Yes",
+      "boolFalse": "No"
     }
   },
   "theme": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -15,7 +15,9 @@
     "rules": "Reglas",
     "notifications": "Notificaciones",
     "reservedHistory": "Historial de viajes reservados",
-    "accountingExport": "Exportar pólizas contables"
+    "accountingExport": "Exportar pólizas contables",
+    "auditLogs": "Bitácora de auditoría",
+    "companyRequests": "Solicitudes"
   },
   "dashboard": {
     "createRequest": "Crear solicitud de viaje",
@@ -32,7 +34,9 @@
     "newCompany": "Crear empresa",
     "userList": "Lista de usuarios",
     "rules": "Reglas",
-    "notifications": "Notificaciones"
+    "notifications": "Notificaciones",
+    "auditLogs": "Bitácora de auditoría",
+    "companyRequests": "Solicitudes"
   },
   "header": {
     "logout": "Cerrar sesión"
@@ -667,6 +671,65 @@
       "reservationsDesc": "Notifica por email cuando se crea una reservación.",
       "adminAlerts": "Alertas administrativas",
       "adminAlertsDesc": "Notifica por email eventos administrativos relevantes."
+    },
+    "companyRequests": {
+      "title": "Solicitudes de la empresa",
+      "folio": "Folio",
+      "title_col": "Título",
+      "requester": "Solicitante",
+      "status": "Estado",
+      "createdAt": "Fecha",
+      "actions": "Acciones",
+      "view": "Ver solicitud",
+      "errorLoading": "Error al cargar las solicitudes."
+    },
+    "auditLogs": {
+      "title": "Bitácora de auditoría",
+      "date": "Fecha",
+      "user": "Usuario afectado",
+      "email": "Correo",
+      "action": "Acción",
+      "seeMore": "ver más",
+      "seeLess": "ver menos",
+      "viewRequest": "Ver solicitud",
+      "errorLoading": "Error al cargar la bitácora de auditoría.",
+      "actions": {
+        "USER_CREATED": "Usuario creado: {{email}} (roles: {{flags}})",
+        "USER_PROFILE_UPDATED": "Perfil actualizado de {{email}} — campos: {{fields}}",
+        "USER_FLAGS_UPDATED": "Roles actualizados de {{email}}: {{flags}}",
+        "USER_DELETED": "Usuario eliminado: {{email}}",
+        "SETTINGS_UPDATED": "Configuración de empresa actualizada: {{fields}}",
+        "REQUEST_CREATED": "Solicitud creada — Folio {{folio}}: \"{{title}}\"",
+        "REQUEST_CANCELLED": "Solicitud cancelada — Folio {{folio}}: \"{{title}}\"",
+        "RULE_CREATED": "Regla de aprobación creada: \"{{name}}\" (orden {{order}})",
+        "RULE_UPDATED": "Regla de aprobación modificada: \"{{name}}\" — campos: {{fields}}",
+        "FIRST_LOGIN": "Primer inicio de sesión: {{email}}"
+      },
+      "fieldNames": {
+        "is_requester": "Solicitante",
+        "is_approver": "Aprobador",
+        "is_soi": "SOI",
+        "is_travelAgent": "Agente de viajes",
+        "is_company_admin": "Admin de empresa",
+        "voucher_deadline_days": "Días límite de comprobación",
+        "name": "Nombre",
+        "last_name": "Apellido",
+        "email": "Correo",
+        "employee_num": "Núm. empleado",
+        "status": "Estado",
+        "password": "Contraseña",
+        "user_name": "Usuario",
+        "level_order": "Orden",
+        "is_active": "Activo",
+        "description": "Descripción",
+        "code": "Código",
+        "applies_to": "Aplica a",
+        "min_amount": "Monto mínimo",
+        "max_amount": "Monto máximo",
+        "required_approvals": "Aprobaciones requeridas"
+      },
+      "boolTrue": "Sí",
+      "boolFalse": "No"
     }
   },
   "theme": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -703,7 +703,8 @@
         "REQUEST_CANCELLED": "Solicitud cancelada — Folio {{folio}}: \"{{title}}\"",
         "RULE_CREATED": "Regla de aprobación creada: \"{{name}}\" (orden {{order}})",
         "RULE_UPDATED": "Regla de aprobación modificada: \"{{name}}\" — campos: {{fields}}",
-        "FIRST_LOGIN": "Primer inicio de sesión: {{email}}"
+        "FIRST_LOGIN": "Primer inicio de sesión: {{email}}",
+        "USERS_IMPORTED": "Importación de usuarios: {{created}} creado(s), {{updated}} actualizado(s), {{unchanged}} sin cambios, {{errors}} error(es)"
       },
       "fieldNames": {
         "is_requester": "Solicitante",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@
  * Authors: Original Moncarca team
  * Last Modification made:
  * 19/05/2026 [Julio Rodriguez] Updated admin guard for notifications page to be company-admin only; added new routes for notifications management and travel agent history; integrated new permissions and flags into route protection logic.
+ * 21/05/2026 [Julio Rodriguez] Added route for AdminAuditLogs page (company admin only).
  */
 
 import { StrictMode } from "react";
@@ -20,6 +21,8 @@ import AdminUsers from "./pages/Admin/AdminUsers.tsx";
 import AdminRules from "./pages/Admin/AdminRules.tsx";
 import AdminNewCompany from "./pages/Admin/AdminNewCompany.tsx";
 import AdminNotifications from "./pages/Admin/AdminNotifications.tsx";
+import AdminAuditLogs from "./pages/Admin/AdminAuditLogs.tsx";
+import AdminCancelledRequests from "./pages/Admin/AdminCancelledRequests.tsx";
 
 import {
   ProtectedRoute,
@@ -162,6 +165,14 @@ export const router = createBrowserRouter([
       {
         path: "/admin/companies/new",
         element: <FlagProtectedRoute requireSystemAdmin><AdminNewCompany /></FlagProtectedRoute>,
+      },
+      {
+        path: "/admin/audit-logs",
+        element: <FlagProtectedRoute requireCompanyAdminOnly><AdminAuditLogs /></FlagProtectedRoute>,
+      },
+      {
+        path: "/admin/company-requests",
+        element: <FlagProtectedRoute requireCompanyAdminOnly><AdminCancelledRequests /></FlagProtectedRoute>,
       },
       /**
        * Permission-protected routes (approvals module).

--- a/src/pages/Admin/AdminAuditLogs.tsx
+++ b/src/pages/Admin/AdminAuditLogs.tsx
@@ -1,0 +1,322 @@
+/**
+ * FileName: AdminAuditLogs.tsx
+ * Description: Admin view for listing user audit logs scoped to the company admin's company.
+ *              Displays who performed an action, which user was affected, the date, and the
+ *              report description. Long reports are truncated and can be expanded inline.
+ *              Company admins only.
+ * Authors: DebugStudio Team
+ * Last Modification made:
+ * 21/05/2026 [Julio Rodriguez] Initial implementation.
+ */
+
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { getRequest } from "../../utils/apiService";
+import { useAuth } from "../../hooks/auth/authContext";
+import GoBack from "../../components/GoBack";
+import RefreshButton from "../../components/RefreshButton";
+import { useTranslation } from "react-i18next";
+
+interface AuditLogUser {
+  id: string;
+  name: string;
+  last_name: string;
+  email: string;
+}
+
+interface AuditLog {
+  id: string;
+  id_user: string;
+  date: string;
+  ip: string;
+  report: string;
+  user?: AuditLogUser;
+}
+
+const ITEMS_PER_PAGE = 10;
+const REPORT_TRUNCATE_LENGTH = 80;
+
+type TFunc = (key: string, opts?: Record<string, unknown>) => string;
+
+function humanizeKV(raw: string, t: TFunc): string {
+  return raw
+    .split(",")
+    .map((pair) => {
+      const eqIdx = pair.indexOf("=");
+      if (eqIdx === -1) return t(`admin.auditLogs.fieldNames.${pair}`, { defaultValue: pair });
+      const key = pair.slice(0, eqIdx);
+      const val = pair.slice(eqIdx + 1);
+      const label = t(`admin.auditLogs.fieldNames.${key}`, { defaultValue: key });
+      const translatedVal =
+        val === "true"
+          ? t("admin.auditLogs.boolTrue", { defaultValue: "Sí" })
+          : val === "false"
+          ? t("admin.auditLogs.boolFalse", { defaultValue: "No" })
+          : val;
+      return `${label}: ${translatedVal}`;
+    })
+    .join(", ");
+}
+
+function parseReport(raw: string, t: TFunc): { text: string; requestId: string | null } {
+  const sep = raw.indexOf("§");
+  if (sep !== -1) {
+    const parts = raw.split("§");
+    const code = parts[0];
+    switch (code) {
+      case "USER_CREATED":
+        return {
+          text: t(`admin.auditLogs.actions.${code}`, {
+            email: parts[1] ?? "",
+            flags: humanizeKV(parts[2] ?? "", t),
+          }),
+          requestId: null,
+        };
+      case "USER_PROFILE_UPDATED":
+        return {
+          text: t(`admin.auditLogs.actions.${code}`, {
+            email: parts[1] ?? "",
+            fields: (parts[2] ?? "")
+              .split(",")
+              .map((f) => t(`admin.auditLogs.fieldNames.${f.trim()}`, { defaultValue: f.trim() }))
+              .join(", "),
+          }),
+          requestId: null,
+        };
+      case "USER_FLAGS_UPDATED":
+        return {
+          text: t(`admin.auditLogs.actions.${code}`, {
+            email: parts[1] ?? "",
+            flags: humanizeKV(parts[2] ?? "", t),
+          }),
+          requestId: null,
+        };
+      case "USER_DELETED":
+        return {
+          text: t(`admin.auditLogs.actions.${code}`, { email: parts[1] ?? "" }),
+          requestId: null,
+        };
+      case "SETTINGS_UPDATED":
+        return {
+          text: t(`admin.auditLogs.actions.${code}`, {
+            fields: humanizeKV(parts[1] ?? "", t),
+          }),
+          requestId: null,
+        };
+      case "REQUEST_CREATED":
+        return {
+          text: t(`admin.auditLogs.actions.${code}`, {
+            folio: parts[1] ?? "",
+            title: parts[2] ?? "",
+          }),
+          requestId: parts[3] ?? null,
+        };
+      case "REQUEST_CANCELLED":
+        return {
+          text: t(`admin.auditLogs.actions.${code}`, {
+            folio: parts[1] ?? "",
+            title: parts[2] ?? "",
+          }),
+          requestId: parts[3] ?? null,
+        };
+      case "RULE_CREATED":
+        return {
+          text: t(`admin.auditLogs.actions.${code}`, {
+            name: parts[1] ?? "",
+            order: parts[2] ?? "",
+          }),
+          requestId: null,
+        };
+      case "RULE_UPDATED":
+        return {
+          text: t(`admin.auditLogs.actions.${code}`, {
+            name: parts[1] ?? "",
+            fields: (parts[2] ?? "")
+              .split(",")
+              .map((f) => t(`admin.auditLogs.fieldNames.${f.trim()}`, { defaultValue: f.trim() }))
+              .join(", "),
+          }),
+          requestId: null,
+        };
+      case "FIRST_LOGIN":
+        return {
+          text: t(`admin.auditLogs.actions.${code}`, { email: parts[1] ?? "" }),
+          requestId: null,
+        };
+      default:
+        return { text: raw, requestId: null };
+    }
+  }
+  // Legacy format with ||req: separator
+  const legacySep = raw.indexOf("||req:");
+  if (legacySep !== -1) {
+    return { text: raw.slice(0, legacySep), requestId: raw.slice(legacySep + 6) };
+  }
+  return { text: raw, requestId: null };
+}
+
+export default function AdminAuditLogs() {
+  const { authState } = useAuth();
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const companyId = authState.companyId;
+
+  const [logs, setLogs] = useState<AuditLog[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+
+  const fetchLogs = async () => {
+    if (!companyId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await getRequest(`/admin/companies/${companyId}/audit-logs`);
+      setLogs(data);
+      setCurrentPage(1);
+      setExpandedIds(new Set());
+    } catch (err: unknown) {
+      const msg =
+        (err as { response?: { data?: { message?: string } } })?.response?.data?.message ??
+        t("admin.auditLogs.errorLoading");
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchLogs();
+  }, [companyId]);
+
+  const totalPages = Math.ceil(logs.length / ITEMS_PER_PAGE);
+  const paginated = logs.slice(
+    (currentPage - 1) * ITEMS_PER_PAGE,
+    currentPage * ITEMS_PER_PAGE,
+  );
+
+  const changePage = (page: number) => {
+    if (page < 1 || page > totalPages) return;
+    setCurrentPage(page);
+  };
+
+  const toggleExpand = (id: string) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+  };
+
+  const formatDate = (iso: string) => new Date(iso).toLocaleString();
+
+  return (
+    <>
+      <GoBack />
+      <div className="flex-1 p-6 bg-[var(--color-card-bg)] rounded-lg shadow-xl">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-2xl font-bold text-[var(--color-page-text-title)]">
+            {t("admin.auditLogs.title")}
+          </h2>
+          <RefreshButton onClick={fetchLogs} />
+        </div>
+
+        {error && (
+          <div className="mb-4 p-3 rounded-md text-sm bg-[var(--color-incorrect-bg)] text-[var(--color-incorrect-text)] border border-[var(--color-incorrect-border)]">
+            {error}
+          </div>
+        )}
+
+        <div className="overflow-x-auto mb-4">
+          <table className="w-full min-w-[700px] text-sm text-gray-500 border-separate border-spacing-y-2">
+            <thead>
+              <tr className="text-xs text-white uppercase bg-[#0a2c6d]">
+                <th className="px-4 py-2 text-center rounded-l-lg w-40">{t("admin.auditLogs.date")}</th>
+                <th className="px-4 py-2 text-center w-44">{t("admin.auditLogs.user")}</th>
+                <th className="px-4 py-2 text-center w-48">{t("admin.auditLogs.email")}</th>
+                <th className="px-4 py-2 text-center rounded-r-lg">{t("admin.auditLogs.action")}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {loading ? (
+                <tr>
+                  <td colSpan={4} className="text-center pt-10 text-gray-500">
+                    {t("common.loading")}
+                  </td>
+                </tr>
+              ) : paginated.length === 0 ? (
+                <tr>
+                  <td colSpan={4} className="text-center pt-10 text-[var(--color-page-text)]">
+                    {t("common.noData")}
+                  </td>
+                </tr>
+              ) : (
+                paginated.map((log) => {
+                  const { text: reportText, requestId } = parseReport(log.report, t);
+                  const isLong = reportText.length > REPORT_TRUNCATE_LENGTH;
+                  const isExpanded = expandedIds.has(log.id);
+                  const displayText =
+                    isLong && !isExpanded
+                      ? reportText.slice(0, REPORT_TRUNCATE_LENGTH) + "…"
+                      : reportText;
+
+                  return (
+                    <tr key={log.id} className="bg-[#4C6997] text-white text-center">
+                      <td className="px-4 py-3 rounded-l-lg text-xs">{formatDate(log.date)}</td>
+                      <td className="px-4 py-3 text-sm">
+                        {log.user ? `${log.user.name} ${log.user.last_name}` : log.id_user}
+                      </td>
+                      <td className="px-4 py-3 text-xs">{log.user?.email ?? "-"}</td>
+                      <td className="px-4 py-3 rounded-r-lg text-center text-xs">
+                        <span>{displayText}</span>
+                        {isLong && (
+                          <button
+                            onClick={() => toggleExpand(log.id)}
+                            className="ml-2 underline text-[#b8d0ff] hover:text-white transition-colors whitespace-nowrap"
+                          >
+                            {isExpanded ? t("admin.auditLogs.seeLess") : t("admin.auditLogs.seeMore")}
+                          </button>
+                        )}
+                        {requestId && (
+                          <button
+                            onClick={() => navigate(`/requests/${requestId}`)}
+                            className="ml-2 px-2 py-0.5 rounded bg-white text-[#0a2c6d] font-semibold hover:bg-[#e8eef8] transition-colors whitespace-nowrap"
+                          >
+                            {t("admin.auditLogs.viewRequest")}
+                          </button>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {totalPages > 1 && (
+          <div className="flex items-center justify-center space-x-4">
+            <button
+              onClick={() => changePage(currentPage - 1)}
+              disabled={currentPage === 1}
+              className="px-3 py-1 rounded-lg bg-[#0a2c6d] text-white disabled:opacity-50"
+            >
+              &lt;
+            </button>
+            <span className="text-[var(--color-page-text)] font-medium">
+              {currentPage} / {totalPages}
+            </span>
+            <button
+              onClick={() => changePage(currentPage + 1)}
+              disabled={currentPage === totalPages}
+              className="px-3 py-1 rounded-lg bg-[#0a2c6d] text-white disabled:opacity-50"
+            >
+              &gt;
+            </button>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/pages/Admin/AdminAuditLogs.tsx
+++ b/src/pages/Admin/AdminAuditLogs.tsx
@@ -143,6 +143,16 @@ function parseReport(raw: string, t: TFunc): { text: string; requestId: string |
           text: t(`admin.auditLogs.actions.${code}`, { email: parts[1] ?? "" }),
           requestId: null,
         };
+      case "USERS_IMPORTED":
+        return {
+          text: t(`admin.auditLogs.actions.${code}`, {
+            created: parts[1] ?? "0",
+            updated: parts[2] ?? "0",
+            unchanged: parts[3] ?? "0",
+            errors: parts[4] ?? "0",
+          }),
+          requestId: null,
+        };
       default:
         return { text: raw, requestId: null };
     }

--- a/src/pages/Admin/AdminCancelledRequests.tsx
+++ b/src/pages/Admin/AdminCancelledRequests.tsx
@@ -1,0 +1,195 @@
+/**
+ * FileName: AdminCancelledRequests.tsx
+ * Description: Admin view listing all travel requests for the company across all statuses.
+ *              Shows folio, title, requester, status, and creation date. Company admins only.
+ * Authors: DebugStudio Team
+ * Last Modification made:
+ * 21/05/2026 [Julio Rodriguez] Initial implementation. Extended to show all requests, not just cancelled ones; added status column.
+ */
+
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { getRequest } from "../../utils/apiService";
+import { useAuth } from "../../hooks/auth/authContext";
+import GoBack from "../../components/GoBack";
+import RefreshButton from "../../components/RefreshButton";
+import { useTranslation } from "react-i18next";
+
+interface RequestUser {
+  name: string;
+  last_name: string;
+  email: string;
+}
+
+interface CompanyRequest {
+  id: string;
+  request_num: number;
+  title: string;
+  status: string;
+  createdAt: string;
+  user?: RequestUser;
+}
+
+const ITEMS_PER_PAGE = 10;
+
+const STATUS_STYLES: Record<string, string> = {
+  "Pending Review":             "bg-yellow-100 text-yellow-800",
+  "Changes Needed":             "bg-orange-100 text-orange-800",
+  "Pending Accounting Approval":"bg-blue-100 text-blue-800",
+  "Pending Refund Approval":    "bg-blue-100 text-blue-800",
+  "Pending Reservations":       "bg-purple-100 text-purple-800",
+  "In Progress":                "bg-green-100 text-green-800",
+  "Pending Vouchers Approval":  "bg-indigo-100 text-indigo-800",
+  "Completed":                  "bg-emerald-100 text-emerald-800",
+  "Denied":                     "bg-red-100 text-red-800",
+  "Cancelled":                  "bg-gray-200 text-gray-700",
+};
+
+function buildFolio(createdAt: string, requestNum: number) {
+  return `${new Date(createdAt).getFullYear()}-${String(requestNum).padStart(3, "0")}`;
+}
+
+export default function AdminCompanyRequests() {
+  const { authState } = useAuth();
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const companyId = authState.companyId;
+
+  const [requests, setRequests] = useState<CompanyRequest[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const fetchRequests = async () => {
+    if (!companyId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await getRequest(`/admin/companies/${companyId}/requests`);
+      setRequests(data);
+      setCurrentPage(1);
+    } catch (err: unknown) {
+      const msg =
+        (err as { response?: { data?: { message?: string } } })?.response?.data?.message ??
+        t("admin.companyRequests.errorLoading");
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchRequests();
+  }, [companyId]);
+
+  const totalPages = Math.ceil(requests.length / ITEMS_PER_PAGE);
+  const paginated = requests.slice(
+    (currentPage - 1) * ITEMS_PER_PAGE,
+    currentPage * ITEMS_PER_PAGE,
+  );
+
+  const changePage = (page: number) => {
+    if (page < 1 || page > totalPages) return;
+    setCurrentPage(page);
+  };
+
+  return (
+    <>
+      <GoBack />
+      <div className="flex-1 p-6 bg-[var(--color-card-bg)] rounded-lg shadow-xl">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-2xl font-bold text-[var(--color-page-text-title)]">
+            {t("admin.companyRequests.title")}
+          </h2>
+          <RefreshButton onClick={fetchRequests} />
+        </div>
+
+        {error && (
+          <div className="mb-4 p-3 rounded-md text-sm bg-[var(--color-incorrect-bg)] text-[var(--color-incorrect-text)] border border-[var(--color-incorrect-border)]">
+            {error}
+          </div>
+        )}
+
+        <div className="overflow-x-auto mb-4">
+          <table className="w-full min-w-[800px] text-sm text-gray-500 border-separate border-spacing-y-2">
+            <thead>
+              <tr className="text-xs text-white uppercase bg-[#0a2c6d]">
+                <th className="px-4 py-2 text-center rounded-l-lg w-28">{t("admin.companyRequests.folio")}</th>
+                <th className="px-4 py-2 text-center">{t("admin.companyRequests.title_col")}</th>
+                <th className="px-4 py-2 text-center w-44">{t("admin.companyRequests.requester")}</th>
+                <th className="px-4 py-2 text-center w-40">{t("admin.companyRequests.status")}</th>
+                <th className="px-4 py-2 text-center w-36">{t("admin.companyRequests.createdAt")}</th>
+                <th className="px-4 py-2 text-center rounded-r-lg w-24">{t("admin.companyRequests.actions")}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {loading ? (
+                <tr>
+                  <td colSpan={6} className="text-center pt-10 text-gray-500">
+                    {t("common.loading")}
+                  </td>
+                </tr>
+              ) : paginated.length === 0 ? (
+                <tr>
+                  <td colSpan={6} className="text-center pt-10 text-[var(--color-page-text)]">
+                    {t("common.noData")}
+                  </td>
+                </tr>
+              ) : (
+                paginated.map((r) => (
+                  <tr key={r.id} className="bg-[#4C6997] text-white text-center">
+                    <td className="px-4 py-3 rounded-l-lg font-mono text-xs">
+                      {buildFolio(r.createdAt, r.request_num)}
+                    </td>
+                    <td className="px-4 py-3 text-sm">{r.title}</td>
+                    <td className="px-4 py-3 text-sm">
+                      {r.user ? `${r.user.name} ${r.user.last_name}` : "-"}
+                    </td>
+                    <td className="px-4 py-3">
+                      <span className={`text-xs px-2 py-1 rounded-full font-semibold ${STATUS_STYLES[r.status] ?? "bg-gray-100 text-gray-700"}`}>
+                        {t(`status.${r.status}`, { defaultValue: r.status })}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-xs">
+                      {new Date(r.createdAt).toLocaleDateString()}
+                    </td>
+                    <td className="px-4 py-3 rounded-r-lg">
+                      <button
+                        onClick={() => navigate(`/requests/${r.id}`)}
+                        className="px-3 py-1 text-xs rounded-md bg-white text-[#0a2c6d] font-semibold hover:bg-[#e8eef8] transition-colors"
+                      >
+                        {t("admin.companyRequests.view")}
+                      </button>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {totalPages > 1 && (
+          <div className="flex items-center justify-center space-x-4">
+            <button
+              onClick={() => changePage(currentPage - 1)}
+              disabled={currentPage === 1}
+              className="px-3 py-1 rounded-lg bg-[#0a2c6d] text-white disabled:opacity-50"
+            >
+              &lt;
+            </button>
+            <span className="text-[var(--color-page-text)] font-medium">
+              {currentPage} / {totalPages}
+            </span>
+            <button
+              onClick={() => changePage(currentPage + 1)}
+              disabled={currentPage === totalPages}
+              className="px-3 py-1 rounded-lg bg-[#0a2c6d] text-white disabled:opacity-50"
+            >
+              &gt;
+            </button>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/pages/Admin/AdminCancelledRequests.tsx
+++ b/src/pages/Admin/AdminCancelledRequests.tsx
@@ -146,7 +146,7 @@ export default function AdminCompanyRequests() {
                       {r.user ? `${r.user.name} ${r.user.last_name}` : "-"}
                     </td>
                     <td className="px-4 py-3">
-                      <span className={`text-xs px-2 py-1 rounded-full font-semibold ${STATUS_STYLES[r.status] ?? "bg-gray-100 text-gray-700"}`}>
+                      <span className={`text-xs px-2 py-1 rounded-full font-semibold box-decoration-clone leading-snug ${STATUS_STYLES[r.status] ?? "bg-gray-100 text-gray-700"}`}>
                         {t(`status.${r.status}`, { defaultValue: r.status })}
                       </span>
                     </td>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -3,7 +3,7 @@
  * Description: Renders the main dashboard page with a grid of mosaics linking to different sections of the application based on user permissions, and includes tutorial logic for first-time visitors.
  * Authors: Original Moncarca team
  * Last Modification made:
- * 19/05/2026 [Julio Rodriguez]: Hide travel history mosaic for admin users; use view_travel_agent_history for TA history mosaic; add notifications mosaic for company admins only.
+ * 21/05/2026 [Julio Rodriguez] Added new company admin pages for logs and seeing requests in the company; updated mosaics to conditionally render based on permissions and admin status; added tutorial logic for first-time visitors to the dashboard.
  */
 
 import { useEffect } from "react";
@@ -97,6 +97,12 @@ export const Dashboard = ({title}:DashboardProps) => {
         )}
         {authState.isCompanyAdmin && (
           <Mosaic title={t('dashboard.notifications')} iconPath="/assets/crear_solicitud_de_viaje.png" link="/admin/notifications" id="notifications"/>
+        )}
+        {authState.isCompanyAdmin && (
+          <Mosaic title={t('dashboard.auditLogs')} iconPath="/assets/historial_de_viajes.png" link="/admin/audit-logs" id="audit_logs"/>
+        )}
+        {authState.isCompanyAdmin && (
+          <Mosaic title={t('dashboard.companyRequests')} iconPath="/assets/historial_de_viajes.png" link="/admin/company-requests" id="company_requests"/>
         )}
       </div>
     </Tutorial>


### PR DESCRIPTION
## What
Añade la página de bitácora de auditoría (`/admin/audit-logs`) y vista de solicitudes de empresa (`/admin/company-requests`) para administradores. Las acciones del log se traducen automáticamente al idioma activo usando un parser estructurado con códigos de acción y nombres de campo legibles.

## Why
Closes #28

## How to test (optional)
- Entrar como company admin → verificar que "Bitácora de auditoría" y "Solicitudes" aparecen en el sidebar
- En la bitácora: acciones deben mostrarse en español/inglés según el idioma activo (ej. "Usuario creado: correo@empresa.com")
- Campos como `voucher_deadline_days` deben mostrarse como "Días límite de comprobación: 7"
- Solicitudes con ID deben mostrar botón "Ver solicitud" que navega correctamente
- En solicitudes de empresa: todas las solicitudes con badge de estado por color

## PR Targeting Checklist
- [x] This PR targets the `develop` branch (for most changes)
- [ ] This PR targets the `main` branch (ONLY for release branches or hotfixes)

⚠️ IMPORTANT: PRs to `main` should only come from `develop` or release branches.
If this is a feature or bugfix PR, please retarget to `develop`.