### PR TITLE
test(frontend): stabilize travel request unit and E2E cypress tests

### DIFF
--- a/cypress/e2e/CreateRequest.cy.ts
+++ b/cypress/e2e/CreateRequest.cy.ts
@@ -37,35 +37,49 @@ describe("Create Travel Request as Requester", () => {
         cy.get('a[data-cy="mosaic-crear-solicitud-de-viaje"]').should("be.visible");
         cy.get('a[data-cy="mosaic-crear-solicitud-de-viaje"]').click();
         cy.url().should("include", "/requests/create");
-        cy.contains("Datos del Viaje").should("be.visible");
-        cy.get('input[name="motive"]').should("be.visible");
+        cy.contains("Datos del viaje").should("be.visible");
+        cy.get('input[id="motive"]').should("be.visible");
         cy.get('input[id="title"]').should("be.visible");
-        cy.get('button[id="id_origin_city"]').should("be.visible");
+        cy.get('input[id="id_origin_city"]').should("be.visible");
         cy.get('button[id="priority"]').should("be.visible");
-        cy.get('input[name="advance_money"]').should("be.visible");
-        cy.get('textarea[name="requirements"]').should("be.visible");
-        cy.get('button[id="destination-0"]').should("be.visible");
+        cy.get('input[id="advance_money"]').should("be.visible");
+        cy.get('input[id="currency"]').should("be.visible");
+        cy.get('textarea[id="requirements"]').should("be.visible");
+        cy.get('input[id="destination-0"]').should("be.visible");
         cy.get('input[id="details-0"]').should("be.visible");
         cy.get('input[id="departure-0"]').should("be.visible");
-        cy.get('input[id="arrival-0"]').should("be.visible");
-        cy.get('input[id="stay-days-0"]').should("be.visible");
+        cy.get('input[id="return_date"]').should("be.visible");
         cy.get('button[id="hotel-0"]').should("be.visible");
         cy.get('button[id="plane-0"]').should("be.visible");
-        cy.get('button[type="submit"]').should("be.visible");
-        cy.get('input[name="motive"]').type("Business trip");
+        cy.get('button[id="create_travel_request"]').should("be.visible");
+
+        cy.get('input[id="motive"]').type("Business trip");
         cy.get('input[id="title"]').type("Trip to New York");
-        cy.get('button[id="id_origin_city"]').click();
-        cy.contains('span', 'Mexico City, Mexico').click();
+        
+        // Select Origin City
+        cy.get('input[id="id_origin_city"]').click().type("Mexico City");
+        cy.contains("Mexico City, Mexico").click();
+
+        // Select Priority
         cy.get('button[id="priority"]').click();
-        cy.contains('span', 'Alta').click();
-        cy.get('input[name="advance_money"]').type("1000");
-        cy.get('textarea[name="requirements"]').type("Plane and hotel booking required");
-        cy.get('button[id="destination-0"]').click();
-        cy.contains('span', 'New York, USA').click();
+        cy.contains("Alta").click();
+
+        // Fill Advance Money and Currency
+        cy.get('input[id="advance_money"]').clear().type("1000");
+        cy.get('input[id="currency"]').click();
+        cy.contains("MXN - Peso Mexicano").click();
+
+        cy.get('textarea[id="requirements"]').type("Plane and hotel booking required");
+
+        // Select Destination
+        cy.get('input[id="destination-0"]').click().type("New York");
+        cy.contains("New York, USA").click();
+
         cy.get('input[id="details-0"]').type("Details about the trip");
         cy.get('input[id="departure-0"]').type("2025-11-01");
-        cy.get('input[id="arrival-0"]').type("2025-11-10");
-        cy.get('button[type="submit"]').click();
-        cy.contains('¡Solicitud de viaje creada exitosamente!').should('be.visible');
+        cy.get('input[id="return_date"]').type("2025-11-10");
+
+        cy.get('button[id="create_travel_request"]').click();
+        cy.contains('Solicitud creada exitosamente').should('be.visible');
     });
 });

--- a/src/__tests__/components/FilePreviewer.test.tsx
+++ b/src/__tests__/components/FilePreviewer.test.tsx
@@ -17,7 +17,6 @@ vi.mock("../../utils/formatDate", () => ({
   default: vi.fn((date) => `Formatted: ${date}`),
 }));
 
-// Mirror the real fix: mock also handles string amounts (as PostgreSQL sends them)
 vi.mock("../../utils/formatMoney", () => ({
   default: vi.fn((amount) => {
     const n = typeof amount === "number" ? amount : parseFloat(amount);

--- a/src/__tests__/components/travel-requests/TravelRequestForm.test.tsx
+++ b/src/__tests__/components/travel-requests/TravelRequestForm.test.tsx
@@ -6,10 +6,10 @@
  * create/update mutations) are mocked to isolate component behavior and verify payload structure.
  * Authors: Original Moncarca team
  * Last Modification made:
- * 24/02/2026 [Rebeca Davila Araiza] Added detailed comments and documentation for clarity and maintainability.
+ * 25/05/2026 [Diego de la Vega] Fixed date format to be compatible with HTML input type=date.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import TravelRequestForm from "../../../components/travel-requests/TravelRequestForm";
 import { useNavigate } from "react-router-dom";
@@ -21,9 +21,9 @@ import { useUpdateTravelRequest } from "../../../hooks/requests/useUpdateRequest
 
 // Polyfill ResizeObserver for jsdom
 class ResizeObserverMock {
-  observe() {}
-  unobserve() {}
-  disconnect() {}
+  observe() { }
+  unobserve() { }
+  disconnect() { }
 }
 (global as any).ResizeObserver = ResizeObserverMock;
 
@@ -38,6 +38,68 @@ vi.mock("../../../hooks/requests/useCreateRequest", () => ({
 vi.mock("../../../hooks/requests/useUpdateRequest", () => ({
   useUpdateTravelRequest: vi.fn(),
 }));
+
+// Mock Headless UI Select and SearchableSelect to render standard DOM elements inline
+vi.mock("../../../components/ui/SearchableSelect", () => {
+  return {
+    default: ({ options, value, onChange, placeholder, id }: any) => {
+      return (
+        <div data-testid={`wrapper-${id}`}>
+          <input
+            id={id}
+            aria-label={placeholder}
+            placeholder={placeholder}
+            value={value?.name || ""}
+            onChange={() => { }}
+            readOnly
+          />
+          <div role="listbox">
+            {options.map((opt: any) => (
+              <div
+                key={opt.id}
+                role="option"
+                aria-selected={value?.id === opt.id}
+                onClick={() => onChange(opt)}
+              >
+                {opt.name}
+              </div>
+            ))}
+          </div>
+        </div>
+      );
+    }
+  };
+});
+
+vi.mock("../../../components/ui/Select", () => {
+  return {
+    default: ({ options, value, onChange, placeholder, id }: any) => {
+      return (
+        <div data-testid={`wrapper-${id}`}>
+          <button
+            id={id}
+            aria-label={placeholder}
+            type="button"
+          >
+            {value?.name || placeholder}
+          </button>
+          <div role="listbox">
+            {options.map((opt: any) => (
+              <div
+                key={opt.id}
+                role="option"
+                aria-selected={value?.id === opt.id}
+                onClick={() => onChange(opt)}
+              >
+                {opt.name}
+              </div>
+            ))}
+          </div>
+        </div>
+      );
+    }
+  };
+});
 
 
 // Shared test data
@@ -66,7 +128,7 @@ beforeEach(() => {
 });
 
 // Tests
- 
+
 describe("TravelRequestForm", () => {
   it("renders the form with initial values", () => {
     render(<TravelRequestForm />);
@@ -74,22 +136,22 @@ describe("TravelRequestForm", () => {
     expect(screen.getByLabelText(/título/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/motivo/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/prioridad/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/dinero adelantado/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/anticipo/i)).toBeInTheDocument();
   });
 
   it("shows validation errors for required fields", async () => {
     render(<TravelRequestForm />);
-    await userEvent.click(screen.getByRole("button", { name: /crear viaje/i }));
+    await userEvent.click(screen.getByRole("button", { name: /crear solicitud/i }));
 
     await waitFor(() => {
       expect(
-        screen.getByText(/escribe el título del viaje/i)
+        screen.getByText(/por favor escribe un título/i)
       ).toBeInTheDocument();
       expect(
-        screen.getByText(/escribe el motivo del viaje/i)
+        screen.getByText(/por favor escribe un motivo/i)
       ).toBeInTheDocument();
       expect(
-        screen.getByText(/selecciona fecha de llegada/i)
+        screen.getByText(/selecciona una fecha de regreso/i)
       ).toBeInTheDocument();
     });
   });
@@ -98,26 +160,15 @@ describe("TravelRequestForm", () => {
     render(<TravelRequestForm />);
 
     await userEvent.click(
-      screen.getByRole("button", { name: /\+ añadir destino/i })
+      screen.getByRole("button", { name: /agregar destino/i })
     );
     expect(screen.getByText(/destino #2/i)).toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole("button", { name: /quitar/i }));
+    await userEvent.click(screen.getByRole("button", { name: /eliminar/i }));
     expect(screen.queryByText(/destino #2/i)).not.toBeInTheDocument();
   });
 
-  it("calculates stay days based on arrival and departure dates", async () => {
-    render(<TravelRequestForm />);
-
-    await userEvent.type(screen.getByLabelText(/fecha salida/i), "2024-03-01");
-    await userEvent.type(screen.getByLabelText(/fecha llegada/i), "2024-03-05");
-
-    await waitFor(() => {
-      expect(screen.getByLabelText(/no\. días estancia/i)).toHaveValue(4);
-    });
-  });
-
-  it("submits the form with valid data", async () => {
+  it("submits the form with valid data and auto-derived stay days", async () => {
     const mockCreateMutation = vi.fn();
     (useCreateTravelRequest as any).mockReturnValue({
       createTravelRequestMutation: mockCreateMutation,
@@ -130,45 +181,51 @@ describe("TravelRequestForm", () => {
     // basic fields
     await user.type(screen.getByLabelText(/título/i), "Test Trip");
     await user.type(screen.getByLabelText(/motivo/i), "Business Meeting");
-    await user.type(screen.getByLabelText(/dinero adelantado/i), "1000");
+    await user.clear(screen.getByLabelText(/anticipo/i));
+    await user.type(screen.getByLabelText(/anticipo/i), "1000");
 
     // origin city dropdown
-    await user.click(screen.getByLabelText(/ciudad origen/i));
-    await user.click(
-      await screen.findByRole("option", { name: "Destination 1" })
-    );
+    const originWrapper = screen.getByTestId("wrapper-id_origin_city");
+    await user.click(within(originWrapper).getByRole("option", { name: "Destination 1" }));
 
     // priority dropdown
-    await user.click(screen.getByLabelText(/prioridad/i));
-    await user.click(await screen.findByRole("option", { name: "Alta" }));
+    const priorityWrapper = screen.getByTestId("wrapper-priority");
+    await user.click(within(priorityWrapper).getByRole("option", { name: "Alta" }));
+
+    // currency dropdown
+    const currencyWrapper = screen.getByTestId("wrapper-currency");
+    await user.click(within(currencyWrapper).getByRole("option", { name: "MXN - Peso Mexicano" }));
 
     // destination dropdown inside Destino #1
-    await user.click(screen.getByLabelText(/destino/i));
-    await user.click(
-      await screen.findByRole("option", { name: "Destination 1" })
-    );
+    const destWrapper = screen.getByTestId("wrapper-destination-0");
+    await user.click(within(destWrapper).getByRole("option", { name: "Destination 1" }));
 
     // remaining fields inside Destino #1
     await user.type(screen.getByLabelText(/detalles/i), "Hotel details");
-    await user.type(screen.getByLabelText(/fecha salida/i), "2024-03-01");
-    await user.type(screen.getByLabelText(/fecha llegada/i), "2024-03-05");
+
+    // Fill departure date for Destino #1
+    await user.type(screen.getByLabelText(/fecha de salida/i), "2026-06-01");
+
+    // Fill return date (trip end)
+    await user.type(screen.getByLabelText(/fecha de regreso/i), "2026-06-05");
 
     // submit 
-    await user.click(screen.getByRole("button", { name: /crear viaje/i }));
+    await user.click(screen.getByRole("button", { name: /crear solicitud/i }));
 
     await waitFor(() => {
       expect(mockCreateMutation).toHaveBeenCalledWith({
         id_origin_city: "1",
-        title: "Business Meeting", // motive is used as title in payload
+        title: "Test Trip",
         motive: "Business Meeting",
         priority: "alta",
         advance_money: 1000,
+        currency: "MXN",
         requirements: undefined,
         requests_destinations: [
           {
             id_destination: "1",
             destination_order: 1,
-            stay_days: 4,
+            stay_days: 4, // 2026-06-05 - 2026-06-01 = 4 days
             arrival_date: expect.any(String),
             departure_date: expect.any(String),
             is_hotel_required: true,
@@ -196,26 +253,26 @@ describe("TravelRequestForm", () => {
     // Same happy-path typing sequence as above
     await user.type(screen.getByLabelText(/título/i), "Test Trip");
     await user.type(screen.getByLabelText(/motivo/i), "Business Meeting");
-    await user.type(screen.getByLabelText(/dinero adelantado/i), "1000");
+    await user.clear(screen.getByLabelText(/anticipo/i));
+    await user.type(screen.getByLabelText(/anticipo/i), "1000");
 
-    await user.click(screen.getByLabelText(/ciudad origen/i));
-    await user.click(
-      await screen.findByRole("option", { name: "Destination 1" })
-    );
+    const originWrapper = screen.getByTestId("wrapper-id_origin_city");
+    await user.click(within(originWrapper).getByRole("option", { name: "Destination 1" }));
 
-    await user.click(screen.getByLabelText(/prioridad/i));
-    await user.click(await screen.findByRole("option", { name: "Alta" }));
+    const priorityWrapper = screen.getByTestId("wrapper-priority");
+    await user.click(within(priorityWrapper).getByRole("option", { name: "Alta" }));
 
-    await user.click(screen.getByLabelText(/destino/i));
-    await user.click(
-      await screen.findByRole("option", { name: "Destination 1" })
-    );
+    const currencyWrapper = screen.getByTestId("wrapper-currency");
+    await user.click(within(currencyWrapper).getByRole("option", { name: "MXN - Peso Mexicano" }));
+
+    const destWrapper = screen.getByTestId("wrapper-destination-0");
+    await user.click(within(destWrapper).getByRole("option", { name: "Destination 1" }));
 
     await user.type(screen.getByLabelText(/detalles/i), "Hotel details");
-    await user.type(screen.getByLabelText(/fecha salida/i), "2024-03-01");
-    await user.type(screen.getByLabelText(/fecha llegada/i), "2024-03-05");
+    await user.type(screen.getByLabelText(/fecha de salida/i), "2026-06-01");
+    await user.type(screen.getByLabelText(/fecha de regreso/i), "2026-06-05");
 
-    await user.click(screen.getByRole("button", { name: /crear viaje/i }));
+    await user.click(screen.getByRole("button", { name: /crear solicitud/i }));
 
     await waitFor(() => expect(mockCreateMutation).toHaveBeenCalled());
   });

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -3,7 +3,55 @@
  * Description: Sets up the testing environment for the application by importing necessary testing libraries and configurations, ensuring that tests have access to custom matchers and utilities for DOM testing.
  * Authors: Original Moncarca team
  * Last Modification made:
- * 25/02/2026 [Santiago-Coronado] Added detailed comments and documentation for clarity and maintainability.
+ * 25/05/2026 [Diego de la Vega] Configured a robust react-i18next mock that resolves nested keys using es.json translations with the help of Gemini AI.
  */
 
 import "@testing-library/jest-dom";
+import { vi } from "vitest";
+import es from "../i18n/locales/es.json";
+
+// Helper function to resolve dotted keys from the JSON structure
+function resolveKey(key: string): string {
+  const parts = key.split(".");
+  let current: any = es;
+  for (const part of parts) {
+    if (current && typeof current === "object" && part in current) {
+      current = current[part];
+    } else {
+      return key;
+    }
+  }
+  return typeof current === "string" ? current : key;
+}
+
+vi.mock("react-i18next", () => {
+  return {
+    useTranslation: () => {
+      return {
+        t: (key: string, options?: any) => {
+          let value = resolveKey(key);
+          if (options) {
+            Object.keys(options).forEach((optKey) => {
+              value = value.replace(`{{${optKey}}}`, String(options[optKey]));
+            });
+          }
+          return value;
+        },
+        i18n: {
+          changeLanguage: () => Promise.resolve(),
+          language: "es",
+        },
+      };
+    },
+    initReactI18next: {
+      type: "3rdParty",
+      init: () => { },
+    },
+  };
+});
+
+// Extend Vitest's expect matchers with Jest-DOM matchers for TypeScript
+declare module "vitest" {
+  interface Assertion<T = any> extends jest.Matchers<void, T> {}
+  interface AsymmetricMatchersContaining extends jest.Matchers<void, any> {}
+}


### PR DESCRIPTION
test(frontend): stabilize travel request unit and E2E cypress tests

## What
Stabilizes the travel request testing suite by mock rendering Headless UI Select/SearchableSelect components inline, mapping new currency selections, and resolving missing TypeScript Jest-DOM matcher typings (`toBeInTheDocument`). 
It also refactors the Cypress E2E `CreateRequest.cy.ts` test to match the single global `return_date` redesign.

## How to test (optional)
1. In the `Frontend` directory, run the Vitest unit tests:
   ```bash
   npx vitest run src/__tests__/components/travel-requests/TravelRequestForm.test.tsx
