### PR TITLE
feat(https): Added https conf for certs and updated automatic tests

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,10 +1,18 @@
 import { defineConfig } from "cypress";
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const hasCerts = fs.existsSync(path.resolve(__dirname, 'certs/frontend-key.pem'));
 
 export default defineConfig({
   e2e: {
-    baseUrl: "http://localhost:5173", // Vite's default port
+    baseUrl: hasCerts ? "https://localhost:5173" : "http://localhost:5173", // Vite's default port
     specPattern: "cypress/e2e/**/*.cy.{js,jsx,ts,tsx}",
     supportFile: "cypress/support/e2e.ts",
-     screenshotsFolder: 'coverage/cypress/screenshots',
+    screenshotsFolder: 'coverage/cypress/screenshots',
   },
 });

--- a/cypress/e2e/CreateRequest.cy.ts
+++ b/cypress/e2e/CreateRequest.cy.ts
@@ -3,7 +3,7 @@
  * Description: End-to-end tests for creating a travel request in the Monarca application.
  * Authors: Original Moncarca team
  * Last Modification made:
- * 11/05/2026 [Diego de la Vega] Updated CreateRequest tests for login flow reliability
+ * 25/05/2026 [Diego de la Vega] Fixed date format to be compatible with HTML input type=date.
  */
 
 /**
@@ -37,35 +37,49 @@ describe("Create Travel Request as Requester", () => {
         cy.get('a[data-cy="mosaic-crear-solicitud-de-viaje"]').should("be.visible");
         cy.get('a[data-cy="mosaic-crear-solicitud-de-viaje"]').click();
         cy.url().should("include", "/requests/create");
-        cy.contains("Datos del Viaje").should("be.visible");
-        cy.get('input[name="motive"]').should("be.visible");
+        cy.contains("Datos del viaje").should("be.visible");
+        cy.get('input[id="motive"]').should("be.visible");
         cy.get('input[id="title"]').should("be.visible");
-        cy.get('button[id="id_origin_city"]').should("be.visible");
+        cy.get('input[id="id_origin_city"]').should("be.visible");
         cy.get('button[id="priority"]').should("be.visible");
-        cy.get('input[name="advance_money"]').should("be.visible");
-        cy.get('textarea[name="requirements"]').should("be.visible");
-        cy.get('button[id="destination-0"]').should("be.visible");
+        cy.get('input[id="advance_money"]').should("be.visible");
+        cy.get('input[id="currency"]').should("be.visible");
+        cy.get('textarea[id="requirements"]').should("be.visible");
+        cy.get('input[id="destination-0"]').should("be.visible");
         cy.get('input[id="details-0"]').should("be.visible");
         cy.get('input[id="departure-0"]').should("be.visible");
-        cy.get('input[id="arrival-0"]').should("be.visible");
-        cy.get('input[id="stay-days-0"]').should("be.visible");
+        cy.get('input[id="return_date"]').should("be.visible");
         cy.get('button[id="hotel-0"]').should("be.visible");
         cy.get('button[id="plane-0"]').should("be.visible");
-        cy.get('button[type="submit"]').should("be.visible");
-        cy.get('input[name="motive"]').type("Business trip");
+        cy.get('button[id="create_travel_request"]').should("be.visible");
+
+        cy.get('input[id="motive"]').type("Business trip");
         cy.get('input[id="title"]').type("Trip to New York");
-        cy.get('button[id="id_origin_city"]').click();
-        cy.contains('span', 'Mexico City, Mexico').click();
+
+        // Select Origin City
+        cy.get('input[id="id_origin_city"]').click().type("Mexico City");
+        cy.contains("Mexico City, Mexico").click();
+
+        // Select Priority
         cy.get('button[id="priority"]').click();
-        cy.contains('span', 'Alta').click();
-        cy.get('input[name="advance_money"]').type("1000");
-        cy.get('textarea[name="requirements"]').type("Plane and hotel booking required");
-        cy.get('button[id="destination-0"]').click();
-        cy.contains('span', 'New York, USA').click();
+        cy.contains("Alta").click();
+
+        // Fill Advance Money and Currency
+        cy.get('input[id="advance_money"]').clear().type("1000");
+        cy.get('input[id="currency"]').click();
+        cy.contains("MXN - Peso Mexicano").click();
+
+        cy.get('textarea[id="requirements"]').type("Plane and hotel booking required");
+
+        // Select Destination
+        cy.get('input[id="destination-0"]').click().type("New York");
+        cy.contains("New York, USA").click();
+
         cy.get('input[id="details-0"]').type("Details about the trip");
         cy.get('input[id="departure-0"]').type("2025-11-01");
-        cy.get('input[id="arrival-0"]').type("2025-11-10");
-        cy.get('button[type="submit"]').click();
-        cy.contains('¡Solicitud de viaje creada exitosamente!').should('be.visible');
+        cy.get('input[id="return_date"]').type("2025-11-10");
+
+        cy.get('button[id="create_travel_request"]').click();
+        cy.contains('Solicitud creada exitosamente').should('be.visible');
     });
 });


### PR DESCRIPTION
What
- Updated cypress.config.js to dynamically detect local certificates and switch between HTTP and HTTPS for baseUrl.
- Updated the e2e travel request test (CreateRequest.cy.ts) to resolve HTML date compatibility issues, adjust UI input selectors, and match the latest form structure.

Why
To prevent end-to-end tests from breaking when running the frontend under local HTTPS, while maintaining full backward compatibility for developers still running under plain HTTP. The date inputs and selectors were also updated to align with the latest UI form adjustments.

How to test (optional)
1. Start the frontend application in either HTTP or HTTPS mode.
2. Open Cypress using npm run cypress:open.
3. Run the Create Travel Request test suite to verify that the end-to-end flow completes successfully without certificate or selector failures.
