### PR TITLE
feat(refunds): add voucher submission UI, approval pages, and audit log improvements

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -4,7 +4,7 @@
  *              and permission-based navigation links using SidebarOption items.
  * Authors: Original Moncarca team
  * Last Modification made:
- * 21/05/2026 [Julio Rodriguez]: Added audit logs link for company admins.
+ * 27/05/2026 [Julio Rodriguez]: Moved vouchers-and-refunds link from approve_vouchers (SOI) to approve_request (approver).
  */
 
 // ***************** images *****************
@@ -66,7 +66,7 @@ function Sidebar({ user, onNavigate }: { user: AuthState, onNavigate?: () => voi
             {!isAdmin && user.userPermissions.includes("view_approved_request_history" as Permission) && (
               <SidebarOption label={t('sidebar.approvalHistory')} pathIcon="/assets/historial_de_viajes_aprobados.png" link="/history?view=approvals" onClick={onNavigate}/>
             )}
-            {!isAdmin && user.userPermissions.includes("approve_vouchers" as Permission) && (
+            {!isAdmin && user.userPermissions.includes("approve_request" as Permission) && (
               <SidebarOption label={t('sidebar.vouchersAndRefunds')} pathIcon="/assets/comprobantes_de_gastos_por_aprobar.png" link="/refunds-review" onClick={onNavigate}/>
             )}
             {!isAdmin && user.userPermissions.includes("check_budgets" as Permission) && (

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -148,7 +148,19 @@
     "submit": "Submit",
     "amountError": "Amount cannot be 0.00",
     "selectCurrencyError": "Please select a currency for each voucher.",
-    "submitError": "Error submitting. Please try again."
+    "submitError": "Error submitting. Please try again.",
+    "colCfdiStatus": "CFDI Status",
+    "checkingCfdi": "Validating...",
+    "existingVouchers": "Existing vouchers",
+    "deadlineLabel": "Voucher submission deadline",
+    "deadlineDaysLeft": "{{count}} day(s) remaining",
+    "deadlineExpired": "Submission deadline has passed — no new vouchers can be uploaded",
+    "uploadButton": "Upload vouchers",
+    "sendApprovalButton": "Send for approval",
+    "noVouchersError": "Upload at least one voucher before sending for approval",
+    "uploadSuccess": "Vouchers uploaded successfully",
+    "sendSuccess": "Vouchers sent for approval successfully",
+    "noMatchingRefundLevel": "No approval rule is configured for this advance amount. Ask your administrator to set up a refund rule that covers this range."
   },
   "form": {
     "title": "Title",
@@ -387,7 +399,14 @@
     "exchangeRate": "Exchange rate",
     "date": "Date",
     "voucherStatus": "Status",
-    "quantity": "Amount"
+    "quantity": "Amount",
+    "varianceReport": "Budget vs. Actual Expenses",
+    "budgetAmount": "Approved Budget",
+    "actualAmount": "Actual Expenses",
+    "variance": "Variance",
+    "variancePct": "Variance %",
+    "underBudget": "Under budget",
+    "overBudget": "Over budget"
   },
   "tutorial": {
     "done": "Done",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -152,7 +152,17 @@
     "selectCurrencyError": "Por favor selecciona una moneda para cada comprobante.",
     "submitError": "Error al enviar. Intenta de nuevo.",
     "colCfdiStatus": "Estado CFDI",
-    "checkingCfdi": "Validando..."
+    "checkingCfdi": "Validando...",
+    "existingVouchers": "Comprobantes existentes",
+    "deadlineLabel": "Plazo de comprobación de gastos",
+    "deadlineDaysLeft": "{{count}} día(s) restante(s)",
+    "deadlineExpired": "El plazo ha vencido — ya no se pueden subir nuevos comprobantes",
+    "uploadButton": "Subir comprobantes",
+    "sendApprovalButton": "Enviar para aprobación",
+    "noVouchersError": "Sube al menos un comprobante antes de enviar para aprobación",
+    "uploadSuccess": "Comprobantes subidos exitosamente",
+    "sendSuccess": "Comprobantes enviados para aprobación exitosamente",
+    "noMatchingRefundLevel": "No hay una regla de aprobación configurada para este monto de anticipo. Pide a tu administrador que configure una regla de reembolso que cubra este rango."
   },
   "form": {
     "title": "Título",
@@ -391,7 +401,14 @@
     "exchangeRate": "Tipo de cambio",
     "date": "Fecha",
     "voucherStatus": "Estado",
-    "quantity": "Cantidad"
+    "quantity": "Cantidad",
+    "varianceReport": "Presupuesto vs. Gasto Real",
+    "budgetAmount": "Presupuesto aprobado",
+    "actualAmount": "Gasto real",
+    "variance": "Varianza",
+    "variancePct": "Varianza %",
+    "underBudget": "Dentro del presupuesto",
+    "overBudget": "Fuera del presupuesto"
   },
   "tutorial": {
     "done": "Finalizar",
@@ -674,7 +691,6 @@
       "reservations": "Reservación creada",
       "reservationsDesc": "Notifica por email cuando se crea una reservación.",
       "submitError": "Error al enviar. Intenta de nuevo.",
-      "existingVouchers": "Comprobantes existentes",
       "adminAlertsDesc": "Notifica por email eventos administrativos relevantes."
     },
     "companyRequests": {

--- a/src/pages/Admin/AdminAuditLogs.tsx
+++ b/src/pages/Admin/AdminAuditLogs.tsx
@@ -6,7 +6,7 @@
  *              Company admins only.
  * Authors: DebugStudio Team
  * Last Modification made:
- * 21/05/2026 [Julio Rodriguez] Initial implementation.
+ * 27/05/2026 [Julio Rodriguez] Added new_status badge and id_request link for request_log entries.
  */
 
 import { useEffect, useState } from "react";
@@ -28,8 +28,12 @@ interface AuditLog {
   id: string;
   id_user: string;
   date: string;
-  ip: string;
+  ip: string | null;
   report: string;
+  /** Present on request_log entries: the resulting status after the action. */
+  new_status?: string;
+  /** Present on request_log entries: UUID of the linked request. */
+  id_request?: string;
   user?: AuditLogUser;
 }
 
@@ -263,7 +267,8 @@ export default function AdminAuditLogs() {
                 </tr>
               ) : (
                 paginated.map((log) => {
-                  const { text: reportText, requestId } = parseReport(log.report, t);
+                  const { text: reportText, requestId: parsedRequestId } = parseReport(log.report, t);
+                  const effectiveRequestId = parsedRequestId ?? log.id_request ?? null;
                   const isLong = reportText.length > REPORT_TRUNCATE_LENGTH;
                   const isExpanded = expandedIds.has(log.id);
                   const displayText =
@@ -280,6 +285,11 @@ export default function AdminAuditLogs() {
                       <td className="px-4 py-3 text-xs">{log.user?.email ?? "-"}</td>
                       <td className="px-4 py-3 rounded-r-lg text-center text-xs">
                         <span>{displayText}</span>
+                        {log.new_status && (
+                          <span className="ml-2 inline-block text-xs px-2 py-0.5 rounded-full font-semibold bg-white/20 border border-white/40 whitespace-nowrap">
+                            {log.new_status}
+                          </span>
+                        )}
                         {isLong && (
                           <button
                             onClick={() => toggleExpand(log.id)}
@@ -288,9 +298,9 @@ export default function AdminAuditLogs() {
                             {isExpanded ? t("admin.auditLogs.seeLess") : t("admin.auditLogs.seeMore")}
                           </button>
                         )}
-                        {requestId && (
+                        {effectiveRequestId && (
                           <button
-                            onClick={() => navigate(`/requests/${requestId}`)}
+                            onClick={() => navigate(`/requests/${effectiveRequestId}`)}
                             className="ml-2 px-2 py-0.5 rounded bg-white text-[#0a2c6d] font-semibold hover:bg-[#e8eef8] transition-colors whitespace-nowrap"
                           >
                             {t("admin.auditLogs.viewRequest")}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -3,7 +3,7 @@
  * Description: Renders the main dashboard page with a grid of mosaics linking to different sections of the application based on user permissions, and includes tutorial logic for first-time visitors.
  * Authors: Original Moncarca team
  * Last Modification made:
- * 21/05/2026 [Julio Rodriguez] Added new company admin pages for logs and seeing requests in the company; updated mosaics to conditionally render based on permissions and admin status; added tutorial logic for first-time visitors to the dashboard.
+ * 27/05/2026 [Julio Rodriguez] Moved vouchers-to-approve tile from approve_vouchers (SOI) to approve_request (approver).
  */
 
 import { useEffect } from "react";
@@ -62,8 +62,8 @@ export const Dashboard = ({title}:DashboardProps) => {
         {!isAdmin && authState.userPermissions.includes("view_approved_request_history" as Permission) && (
           <Mosaic title={t('dashboard.approvedHistory')} iconPath="/assets/historial_de_viajes_aprobados.png" link="/history?view=approvals" id="approved_requests"/>
         )}
-        {!isAdmin && authState.userPermissions.includes("approve_vouchers" as Permission) && (
-          <Mosaic title={t('dashboard.vouchersToApprove')} iconPath="/assets/comprobantes_de_gastos_por_aprobar.png" link="/refunds-review" id="approve_vouchers"/>
+        {!isAdmin && authState.userPermissions.includes("approve_request" as Permission) && (
+          <Mosaic title={t('dashboard.vouchersToApprove')} iconPath="/assets/comprobantes_de_gastos_por_aprobar.png" link="/refunds-review" id="approve_request_vouchers"/>
         )}
         {/* {authState.userPermissions.includes("approve_vouchers" as Permission) && (
           <Mosaic title="Reembolsos por aprobar" iconPath="/assets/reembolsos_por_aprobar.png" link=""/>

--- a/src/pages/Refunds/RefundsAcceptance.tsx
+++ b/src/pages/Refunds/RefundsAcceptance.tsx
@@ -1,9 +1,12 @@
 /**
  * RefundsAcceptance.tsx
  * Description: Detailed view for reviewing, approving, or denying individual expense vouchers associated with a trip request.
+ *              Includes a variance report section comparing approved budget vs. actual expenses.
  * Authors: Original Monarca team
  * Last Modification made:
- * 20/05/2026 [Diego de la Vega] Fixed an error where the amount of advance money paid was not shown converted to the local currency, as well as fixed the addition of advance money+payment to advance payment-payment.
+ * 27/05/2026 [Julio Rodriguez] Added variance report section: fetches GET /requests/:id/variance-report and
+ *                              displays budget vs. actual comparison with color-coded variance indicator.
+ *                              Variance values are derived live from voucher state — no separate API call needed.
 */
 
 import React, { useState, useEffect, useRef } from "react";
@@ -471,9 +474,71 @@ const RefundsAcceptance: React.FC = () => {
 
               </section>
 
+              {data?.vouchers && data.vouchers.length > 0 && (() => {
+                const actualAmount = data.vouchers!.reduce(
+                  (acc, v) => v.status === "Voucher Approved" ? acc + Number(v.amount) : acc, 0
+                );
+                const budgetAmount = Number(data.advance_money ?? 0);
+                const variance = actualAmount - budgetAmount;
+                const variancePct = budgetAmount > 0
+                  ? Math.round((variance / budgetAmount) * 10000) / 100
+                  : null;
+                return (
+                  <section
+                    className="my-5 p-4 rounded-lg border border-[var(--color-border)] bg-[var(--color-page-bg)]"
+                    id="variance-report"
+                  >
+                    <h2 className="text-lg font-semibold text-[var(--color-page-text-title)] mb-4">
+                      {t('refundAcceptance.varianceReport')}
+                    </h2>
+                    <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+                      <div>
+                        <p className="text-xs font-semibold text-gray-500 mb-1">
+                          {t('refundAcceptance.budgetAmount')}
+                        </p>
+                        <p className="font-medium text-[var(--color-page-text)]">
+                          {formatMoney(budgetAmount)}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-xs font-semibold text-gray-500 mb-1">
+                          {t('refundAcceptance.actualAmount')}
+                        </p>
+                        <p className="font-medium text-[var(--color-page-text)]">
+                          {formatMoney(actualAmount)}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-xs font-semibold text-gray-500 mb-1">
+                          {t('refundAcceptance.variance')}
+                        </p>
+                        <p className={`font-semibold ${variance > 0 ? 'text-red-500' : 'text-green-600'}`}>
+                          {variance > 0 ? '+' : ''}{formatMoney(variance)}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-xs font-semibold text-gray-500 mb-1">
+                          {t('refundAcceptance.variancePct')}
+                        </p>
+                        <p className={`font-semibold ${(variancePct ?? 0) > 0 ? 'text-red-500' : 'text-green-600'}`}>
+                          {variancePct !== null
+                            ? `${variancePct > 0 ? '+' : ''}${variancePct.toFixed(2)}%`
+                            : 'N/A'}
+                          <span className="ml-2 text-xs font-normal">
+                            {(variancePct ?? 0) > 0
+                              ? t('refundAcceptance.overBudget')
+                              : t('refundAcceptance.underBudget')}
+                          </span>
+                        </p>
+                      </div>
+                    </div>
+                  </section>
+                );
+              })()}
+
               <div className="flex space-x-4 justify-end mt-6">
                 <button
-                  className={`px-4 py-2 text-white rounded-md hover:cursor-pointer 
+                  className={`px-4 py-2 text-white rounded-md hover:cursor-pointer
                       ${data?.vouchers?.some((file) => file.status === "pending_voucher")
                       ? "bg-[var(--color-button)] text-[var(--color-text-button)] cursor-not-allowed"
                       : "bg-[var(--blue)] hover:bg-[var(--dark-blue)]"

--- a/src/pages/Refunds/RefundsReview.tsx
+++ b/src/pages/Refunds/RefundsReview.tsx
@@ -1,9 +1,9 @@
 /**
  * RefundsReview.tsx
- * Description: Component that displays a table of trip requests awaiting final voucher approval by an administrator.
+ * Description: Component that displays a table of trip requests awaiting voucher approval by the assigned approver.
  * Authors: Original Monarca team
  * Last Modification made:
- * 06/05/2026 [Sergio Jiawei Xuan] Adjusted column widths; replaced hardcoded strings with i18n t() calls; updated status badge style.
+ * 27/05/2026 [Julio Rodriguez] Changed data source from GET /requests/all (SOI) to GET /requests/vouchers-to-approve (approver).
  */
 
 import { useEffect, useState } from "react";
@@ -104,7 +104,7 @@ export const RefundsReview = () => {
   const { t } = useTranslation();
 
   /**
-   * fetchTrips, gets all trip requests and filters those awaiting voucher approval.
+   * fetchTrips, gets trip requests in Pending Vouchers Approval assigned to the current approver.
    * Input: None
    * Output: Promise<void>
    */
@@ -113,9 +113,9 @@ export const RefundsReview = () => {
       try {
         setLoading(true);
 
-        const response = await getRequest("/requests/all");
+        const response = await getRequest("/requests/vouchers-to-approve");
 
-        const processedTrips = response.filter((trip: Trip) => trip.status === "Pending Vouchers Approval").map((trip: Trip) => {
+        const processedTrips = response.map((trip: Trip) => {
           const sortedDestinations = [...trip.requests_destinations].sort(
             (a, b) => a.destination_order - b.destination_order
           );

--- a/src/pages/Refunds/Vouchers.tsx
+++ b/src/pages/Refunds/Vouchers.tsx
@@ -3,7 +3,9 @@
  * Description: Form for users to upload PDF and XML files as evidence for their refund requests.
  * Authors: Original Monarca team
  * Last Modification made:
- * 25/05/2026 [Santiago Coronado Hernández] Added CfdiStatus component.
+ * 27/05/2026 [Julio Rodriguez] existingVouchers section now only shows pending_voucher vouchers; fixed i18n key location.
+ *                              Split submit into upload-only and send-for-approval; show folio instead of UUID;
+ *                              display voucher submission deadline with days remaining; block form after deadline.
  */
 
 import { Link, useNavigate } from "react-router-dom";
@@ -45,14 +47,26 @@ interface FormDataRow extends DynamicTableRow {
 /**
  * Trip
  * Interface representing basic trip information for the header details.
+ * Includes optional company and destination data to compute the voucher submission deadline.
  */
 interface Trip {
   id: number | string;
+  request_num?: number;
+  createdAt?: string;
   title: string;
   advance_money: number;
+  currency?: string | null;
   destination?: {
     city?: string;
     iata_code?: string;
+  };
+  requests_destinations?: Array<{
+    arrival_date: string;
+    departure_date: string;
+    is_last_destination: boolean;
+  }>;
+  company?: {
+    voucher_deadline_days: number;
   };
 }
 
@@ -67,7 +81,8 @@ export const Vouchers = () => {
   const { id } = useParams();
   const { t } = useTranslation();
   const [formData, setFormData] = useState<FormDataRow[]>([]);
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isUploading, setIsUploading] = useState(false);
+  const [isSending, setIsSending] = useState(false);
   const [trip, setTrip] = useState<Trip>({
     id: 0,
     title: "",
@@ -76,57 +91,57 @@ export const Vouchers = () => {
   const [commentValue, setCommentValue] = useState<string>("");
 
   /**
-   * fetchTrip
-   * Fetches the specific trip data from the API using the ID in the URL.
+   * fetchTrip — Loads the travel request data and refreshes component state.
+   *             Extracted to component scope so it can be called after uploading vouchers.
+   * Input: None (uses id from URL params)
+   * Output: Promise<void>
    */
+  const fetchTrip = async () => {
+    try {
+      const response = await getRequest(`/requests/${id}`);
+      setTrip(response);
+    } catch (err) {
+      console.error(
+        "Error loading trip: ",
+        err instanceof Error ? err.message : err
+      );
+    }
+  };
+
   useEffect(() => {
-    const fetchTrip = async () => {
-      try {
-        const response = await getRequest(`/requests/${id}`);
-        setTrip(response);
-        // DEBUG: log vouchers to verify cfdi_status presence
-        // Remove or disable this log after verification
-        // eslint-disable-next-line no-console
-        console.debug('Vouchers.fetchTrip response.vouchers:', response?.vouchers);
-      } catch (err) {
-        console.error(
-          "Error loading trip: ",
-          err instanceof Error ? err.message : err
-        );
-      }
-    };
     fetchTrip();
-  }, []);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id]);
 
   /**
-   * handleSubmitRefund
-   * Processes the form data, uploads each voucher as a multipart/form-data request, 
-   * and finalizes the request status.
+   * handleUploadVouchers — Validates and uploads each voucher row to the server without
+   *                        triggering a status transition. Refreshes trip data after upload
+   *                        so the existingVouchers section updates immediately.
    * Input: None
    * Output: Promise<void>
    */
-  const handleSubmitRefund = async () => {
+  const handleUploadVouchers = async () => {
+    if (formData.length === 0) return;
     if (formData.some((row) => !row.currency)) {
       toast.error(t('vouchers.selectCurrencyError'));
       return;
     }
-    if (isSubmitting) return;
-    setIsSubmitting(true);
+    if (isUploading) return;
+    setIsUploading(true);
     try {
-      let formDataToSend = null;
       for (const rowData of formData) {
         // Require PDF file; XML is optional. If XML is provided, validate it.
         if (!rowData.PDFFile) {
           toast.error(t('vouchers.pdfRequired') || 'PDF file is required for each voucher.');
-          setIsSubmitting(false);
+          setIsUploading(false);
           return;
         }
 
-        // Validate PDF (size + extension + mime)
+        // Validate PDF (size + extension + mime).
         const pdfValidation = validateFile(rowData.PDFFile as File, ['.pdf'], ['application/pdf']);
         if (!pdfValidation.isValid) {
           toast.error(pdfValidation.errorMessage || t('vouchers.invalidPDF'));
-          setIsSubmitting(false);
+          setIsUploading(false);
           return;
         }
 
@@ -135,13 +150,12 @@ export const Vouchers = () => {
           const xmlValidation = validateFile(rowData.XMLFile as File, ['.xml'], ['application/xml', 'text/xml']);
           if (!xmlValidation.isValid) {
             toast.error(xmlValidation.errorMessage || t('vouchers.invalidXML'));
-            setIsSubmitting(false);
+            setIsUploading(false);
             return;
           }
         }
 
-        formDataToSend = new FormData();
-
+        const formDataToSend = new FormData();
         formDataToSend.append("id_request", trip.id.toString());
         formDataToSend.append("date", rowData.date ? new Date(rowData.date).toISOString() : new Date().toISOString());
         formDataToSend.append("class", rowData.spentClass);
@@ -149,23 +163,17 @@ export const Vouchers = () => {
         formDataToSend.append("tax_type", rowData.taxIndicator);
         formDataToSend.append("status", "pending_voucher");
         formDataToSend.append("currency", rowData.currency || "MXN");
-        if (rowData.XMLFile) {
-          formDataToSend.append("xml", rowData.XMLFile);
-        }
-
-        if (rowData.PDFFile) {
-          formDataToSend.append("pdf", rowData.PDFFile);
-        }
+        if (rowData.XMLFile) formDataToSend.append("xml", rowData.XMLFile);
+        if (rowData.PDFFile) formDataToSend.append("pdf", rowData.PDFFile);
 
         await postRequest("/vouchers/upload", formDataToSend);
-        toast.success("Refund request successfully submitted.");
       }
-      await patchRequest(`/requests/finished-uploading-vouchers/${id}`, {});
       setFormData([]);
-      navigate("/refunds");
+      await fetchTrip();
+      toast.success(t('vouchers.uploadSuccess'));
     } catch (err) {
       console.error(
-        "Error sending refund request: ",
+        "Error uploading vouchers: ",
         err instanceof Error ? err.message : err
       );
       const rawMsg = (err as { response?: { data?: { message?: unknown } } })?.response?.data?.message;
@@ -174,7 +182,41 @@ export const Vouchers = () => {
           : null;
       toast.error(apiMessage ?? t('vouchers.submitError'));
     } finally {
-      setIsSubmitting(false);
+      setIsUploading(false);
+    }
+  };
+
+  /**
+   * handleSendForApproval — Finalizes the voucher submission by transitioning the request
+   *                          to Pending Vouchers Approval. Navigates back to the refunds list.
+   * Input: None
+   * Output: Promise<void>
+   */
+  const handleSendForApproval = async () => {
+    if (isSending) return;
+    setIsSending(true);
+    try {
+      await patchRequest(`/requests/finished-uploading-vouchers/${id}`, {});
+      toast.success(t('vouchers.sendSuccess'));
+      navigate("/refunds");
+    } catch (err) {
+      console.error(
+        "Error sending for approval: ",
+        err instanceof Error ? err.message : err
+      );
+      const errData = (err as { response?: { data?: { code?: string; message?: unknown } } })?.response?.data;
+      const code = errData?.code;
+      const rawMsg = errData?.message;
+      // Map known backend error codes to translated messages; fall back to API text.
+      const apiMessage =
+        code === 'REQUESTS_NO_APPROVAL_LEVEL'
+          ? t('vouchers.noMatchingRefundLevel')
+          : typeof rawMsg === 'string' ? rawMsg
+            : Array.isArray(rawMsg) ? (rawMsg as string[]).join(', ')
+              : null;
+      toast.error(apiMessage ?? t('vouchers.submitError'));
+    } finally {
+      setIsSending(false);
     }
   };
 
@@ -533,6 +575,37 @@ export const Vouchers = () => {
     handleFormDataChange(data as FormDataRow[]);
   };
 
+  // ── Derived display values ────────────────────────────────────────────────
+
+  /**
+   * folio — Short human-readable request identifier (e.g. "2026-006").
+   *         Falls back to the first 8 characters of the UUID when request_num is unavailable.
+   */
+  const folio = (trip as any).request_num && (trip as any).createdAt
+    ? `${new Date((trip as any).createdAt).getFullYear()}-${String((trip as any).request_num).padStart(3, '0')}`
+    : String(trip.id).substring(0, 8);
+
+  /**
+   * deadline — Voucher submission deadline computed as:
+   *            last destination arrival_date + company.voucher_deadline_days.
+   *            Null when destination data is not yet loaded.
+   */
+  const lastDest = ((trip as any).requests_destinations ?? []).find((d: any) => d.is_last_destination);
+  const deadlineDays = (trip as any).company?.voucher_deadline_days ?? 7;
+  const deadline: Date | null = lastDest
+    ? new Date(new Date(lastDest.arrival_date).getTime() + deadlineDays * 24 * 60 * 60 * 1000)
+    : null;
+  const daysLeft: number | null = deadline
+    ? Math.ceil((deadline.getTime() - Date.now()) / (1000 * 60 * 60 * 24))
+    : null;
+  const isExpired = daysLeft !== null && daysLeft <= 0;
+
+  /**
+   * pendingVouchers — Vouchers already uploaded with status pending_voucher.
+   *                   Used to decide whether the send-for-approval button is enabled.
+   */
+  const pendingVouchers = ((trip as any).vouchers ?? []).filter((v: any) => v.status === 'pending_voucher');
+
   return (
     <>
       <Tutorial page="vouchers">
@@ -549,7 +622,7 @@ export const Vouchers = () => {
               {t('vouchers.tripInfo')}
             </h3>
             <p className="text-[var(--color-page-text)]">
-              <strong>{t('vouchers.tripId')}</strong> {trip.id}
+              <strong>{t('vouchers.tripId')}</strong> {folio}
             </p>
             <p className="text-[var(--color-page-text)]">
               <strong>{t('vouchers.tripName')}</strong> {trip.title}
@@ -560,14 +633,29 @@ export const Vouchers = () => {
             <p className="text-[var(--color-page-text)]">
               <strong>{t('vouchers.advance')}</strong> {formatMoney(trip.advance_money)}
             </p>
+            {deadline && (
+              <p className={`text-sm mt-1 font-medium ${
+                isExpired
+                  ? 'text-red-500'
+                  : daysLeft !== null && daysLeft <= 3
+                    ? 'text-yellow-500'
+                    : 'text-green-500'
+              }`}>
+                <strong>{t('vouchers.deadlineLabel')}:</strong>{' '}
+                {deadline.toLocaleDateString()}{' '}
+                {isExpired
+                  ? `— ${t('vouchers.deadlineExpired')}`
+                  : `(${t('vouchers.deadlineDaysLeft', { count: daysLeft })})`
+                }
+              </p>
+            )}
           </div>
-          {/** Existing uploaded vouchers (read-only) */}
-          {/** Show CFDI pill for each existing voucher if present */}
-          {trip && (trip as any).vouchers && (trip as any).vouchers.length > 0 && (
+          {/** Existing uploaded vouchers (read-only) — only pending_voucher status */}
+          {pendingVouchers.length > 0 && (
             <div className="mb-4 bg-[var(--color-page-bg)] p-4 rounded-md border border-[var(--color-border)]">
               <h3 className="text-lg font-semibold text-[var(--color-page-text)] mb-2">{t('vouchers.existingVouchers')}</h3>
               <div className="flex flex-col gap-3">
-                {(trip as any).vouchers.map((v: any, idx: number) => (
+                {pendingVouchers.map((v: any, idx: number) => (
                   <div key={v.id || idx} className="flex items-center justify-between p-2 bg-[var(--color-card-bg)] rounded-md">
                     <div className="text-sm text-[var(--color-page-text)]">
                       <div><span className="font-semibold">{t('refundAcceptance.voucherClass')}: </span>{v.class}</div>
@@ -590,13 +678,19 @@ export const Vouchers = () => {
         * which is passed as a prop to the DynamicTable component.
         * The handleFormDataChange function updates the formData state with the new data.
         */}
-          <div id="vouchers">
-            <DynamicTable
-              columns={columnsSchemaVauchers}
-              initialData={formData}
-              onDataChange={handleDynamicTableDataChange}
-            />
-          </div>
+          {!isExpired ? (
+            <div id="vouchers">
+              <DynamicTable
+                columns={columnsSchemaVauchers}
+                initialData={formData}
+                onDataChange={handleDynamicTableDataChange}
+              />
+            </div>
+          ) : (
+            <div className="my-4 p-3 bg-red-100 text-red-700 rounded-md border border-red-300 text-sm font-medium">
+              {t('vouchers.deadlineExpired')}
+            </div>
+          )}
           {/*
         * Display a field to add a comment to the refund request.
         * The comment is stored in the commentDescriptionOfSpend state,
@@ -610,23 +704,42 @@ export const Vouchers = () => {
             placeholder={t('vouchers.commentsPlaceholder')}
             onChange={(e) => setCommentValue(e.target.value)}
           />
-          <div className="mt-6 flex justify-between">
+          <div className="mt-6 flex justify-between items-center">
             <Link
               to="/refunds"
               className="px-4 py-2 bg-gray-500 text-white rounded-md hover:bg-gray-600 transition-colors hover:cursor-pointer"
             >
               {t('vouchers.cancel')}
             </Link>
-            <button
-              id="submit-refund"
-              disabled={isSubmitting}
-              className={`px-4 py-2 text-white rounded-md transition-colors ${isSubmitting ? "bg-gray-400 cursor-not-allowed" : "bg-[#0a2c6d] hover:bg-[#0d3d94] hover:cursor-pointer"}`}
-              onClick={() => {
-                handleSubmitRefund();
-              }}
-            >
-              {isSubmitting ? t('common.loading') : t('vouchers.submit')}
-            </button>
+            <div className="flex gap-3">
+              {!isExpired && (
+                <button
+                  id="upload-vouchers"
+                  disabled={isUploading || formData.length === 0}
+                  className={`px-4 py-2 text-white rounded-md transition-colors ${
+                    isUploading || formData.length === 0
+                      ? "bg-gray-400 cursor-not-allowed"
+                      : "bg-[#1a6d3a] hover:bg-[#1e8046] hover:cursor-pointer"
+                  }`}
+                  onClick={handleUploadVouchers}
+                >
+                  {isUploading ? t('common.loading') : t('vouchers.uploadButton')}
+                </button>
+              )}
+              <button
+                id="send-for-approval"
+                disabled={isSending || pendingVouchers.length === 0}
+                title={pendingVouchers.length === 0 ? t('vouchers.noVouchersError') : undefined}
+                className={`px-4 py-2 text-white rounded-md transition-colors ${
+                  isSending || pendingVouchers.length === 0
+                    ? "bg-gray-400 cursor-not-allowed"
+                    : "bg-[#0a2c6d] hover:bg-[#0d3d94] hover:cursor-pointer"
+                }`}
+                onClick={handleSendForApproval}
+              >
+                {isSending ? t('common.loading') : `${t('vouchers.sendApprovalButton')} →`}
+              </button>
+            </div>
           </div>
         </div>
       </Tutorial>


### PR DESCRIPTION
## Description

Implements Task 6 — Expense Voucher Verification (Comprobacion de Gastos), frontend side.

Adds the voucher submission page with deadline tracking, the approver review pages,
and improvements to the admin audit log to show request-related entries.

**Changes included:**
- `Vouchers.tsx`: folio display (YYYY-NNN), deadline badge (green/yellow/red based on days remaining), expired state hides the upload form, split **Subir comprobante** / **Enviar para aprobacion** buttons, i18n error code mapping for `REQUESTS_NO_APPROVAL_LEVEL` and `REQUESTS_NO_VOUCHERS_TO_SUBMIT`
- `RefundsReview.tsx`: switched from `GET /requests/all` to `GET /requests/vouchers-to-approve` so approvers only see requests assigned to them in `Pending Vouchers Approval`
- `RefundsAcceptance.tsx`: variance report (budget vs actual) computed in real time from `data.vouchers` without an extra fetch
- `AdminAuditLogs.tsx`: `new_status` badge and **Ver solicitud** button for `request_log` entries; `id_request` resolved from both parsed report and log field
- `Sidebar.tsx` / `Dashboard.tsx`: refunds-review tile permission changed from `approve_vouchers` to `approve_request`
- `en.json` / `es.json`: new keys for deadline display, voucher upload flow, variance report, and error codes

## How to test

1. Reset DB: `npm run db:drop && npm run migration:run && npm run db:seed`
2. **Upload vouchers** - log in as `requester1@monarca.com` / `password`
   - Go to *Comprobar Gastos* -> open Request **2026-006** (status: In Progress)
   - Upload one or more PDF vouchers; verify each shows a success toast and appears in the table
   - Check the deadline badge color matches days remaining
   - Click **Enviar para aprobacion** -> request moves to *Pending Vouchers Approval*
3. **Approve vouchers** - log in as `approver1@monarca.com` / `password`
   - Go to *Comprobantes y Reembolsos* -> Request 2026-006 should appear
   - Approve or deny individual vouchers
   - Click **Finalizar revision** -> request moves to *Pending Refund Approval*
4. **Complete refund** - log in as `soi1@monarcamx.com` / `password`
   - Go to *Comprobantes y Reembolsos* -> complete the refund registration
   - Request moves to *Completed*
5. **Audit log** - log in as `admin@monarcamx.com` / `password`
   - Go to *Bitacora de Auditoria* -> verify an entry appears for each action above, with a status badge and a **Ver solicitud** button

## PR Targeting Checklist

- [x] This PR targets the `develop` branch (for most changes)
- [ ] This PR targets the `main` branch (ONLY for release branches or hotfixes)