### PR TITLE
feat(ui): redesign login, password recovery, dashboard and header

### DIFF
--- a/public/assets/flag_es.svg
+++ b/public/assets/flag_es.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 750 500" width="750" height="500">
+  <rect width="750" height="500" fill="#c60b1e"/>
+  <rect width="750" height="250" y="125" fill="#ffc400"/>
+</svg>

--- a/public/assets/flag_gb.svg
+++ b/public/assets/flag_gb.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 30" width="60" height="30">
+  <clipPath id="s">
+    <path d="M0,0 v30 h60 v-30 z"/>
+  </clipPath>
+  <clipPath id="t">
+    <path d="M30,15 h30 v15 z v15 h-30 z h-30 v-15 z v-15 h30 z"/>
+  </clipPath>
+  <g clip-path="url(#s)">
+    <path d="M0,0 v30 h60 v-30 z" fill="#012169"/>
+    <path d="M0,0 L60,30 M60,0 L0,30" stroke="#fff" stroke-width="6"/>
+    <path d="M0,0 L60,30 M60,0 L0,30" clip-path="url(#t)" stroke="#C8102E" stroke-width="4"/>
+    <path d="M30,0 v30 M0,15 h60" stroke="#fff" stroke-width="10"/>
+    <path d="M30,0 v30 M0,15 h60" stroke="#C8102E" stroke-width="6"/>
+  </g>
+</svg>

--- a/src/App.css
+++ b/src/App.css
@@ -152,10 +152,10 @@ a {
 }
 
 .dark {
-  --color-page-bg: #161719;
+  --color-page-bg: #0a1628;
   --color-page-text: #f9fafb;
   --color-page-text-title: var(--ultra-light-blue);
-  --color-card-bg: #202225;
+  --color-card-bg: #0d1b2a;
   --color-border: #37393e;
   --color-button: #52525B;
   --color-text-button: #E4E4E7;

--- a/src/App.css
+++ b/src/App.css
@@ -152,11 +152,11 @@ a {
 }
 
 .dark {
-  --color-page-bg: #121212;
+  --color-page-bg: #161719;
   --color-page-text: #f9fafb;
   --color-page-text-title: var(--ultra-light-blue);
-  --color-card-bg: #1d1d1d;
-  --color-border: #3b3b3b;
+  --color-card-bg: #202225;
+  --color-border: #37393e;
   --color-button: #52525B;
   --color-text-button: #E4E4E7;
 

--- a/src/__tests__/main.test.tsx
+++ b/src/__tests__/main.test.tsx
@@ -43,7 +43,7 @@ describe("Router Configuration", () => {
     const loginRoute = routes.find((route) => route.path === "/");
     expect(loginRoute).toBeDefined();
 
-    const registerRoute = routes.find((route) => route.path === "/register");
+    const registerRoute = routes.find((route) => route.path === "/recuperar-contrasena");
     expect(registerRoute).toBeDefined();
 
     // Find protected routes container

--- a/src/__tests__/pages/Login.test.tsx
+++ b/src/__tests__/pages/Login.test.tsx
@@ -52,8 +52,8 @@ describe('LoginPage', () => {
     expect(screen.getByText('Continuar')).toBeInTheDocument();
     expect(screen.getByText('M')).toBeInTheDocument();
     expect(screen.getByText('ONARCA')).toBeInTheDocument();
-    const forgot = screen.getByText('¿Olvidaste tu contraseña?');
-    expect(forgot).toHaveAttribute('href', '/register');
+    const forgot = screen.getByText('¿Olvidaste?');
+    expect(forgot).toHaveAttribute('href', '/recuperar-contrasena');
   });
 
   /* ---------- INTERACCIÓN INPUT ---------- */

--- a/src/components/DarkLightButton.tsx
+++ b/src/components/DarkLightButton.tsx
@@ -27,7 +27,7 @@ export default function DarkModeButton({ className = "", classNameText = ""}: Pr
 
   return (
     <div className={`flex flex-col gap-1 w-[5rem] items-center ${className}`}>
-      <span className={`whitespace-nowrap ${classNameText || "text-[var(--color-page-text)]"}`} style={{fontSize: '13px', fontWeight: 'bold'}}>{isDark ? t('theme.dark') : t('theme.light')}</span>
+      <span className="whitespace-nowrap" style={{fontSize: '13px', fontWeight: 'bold', color: classNameText || '#ffffff'}}>{isDark ? t('theme.dark') : t('theme.light')}</span>
       <Switch
       checked={isDark}
       onChange={handleThemeChange}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -6,20 +6,79 @@
  * 25/02/2026 [Santiago-Coronado] Added detailed comments and documentation for clarity and maintainability.
  */
 
-/**
- * FunctionName: Footer, renders the bottom bar of the application.
- * Input: none
- * Output: JSX footer element with copyright and legal links.
- */
 function Footer() {
-    return (
-        <footer className="w-full bg-[var(--dark-blue)] text-[var(--white)]">
-            <div className="max-w-screen-xl mx-auto p-5 flex justify-between items-center text-xs">
-                <p>Copyright © {new Date().getFullYear()} 02 Solutions.</p>
-                <p>All Rights Reserved | Terms and Conditions | Privacy Policy</p>
-            </div>
-        </footer>
-    )
+  return (
+    <footer
+      className="relative w-full"
+      style={{
+        fontFamily: "Montserrat, sans-serif",
+        background:
+          "linear-gradient(135deg, #001d3d 0%, #00296b 100%)",
+        borderTop: "1px solid rgba(77, 154, 255, 0.18)",
+      }}
+    >
+      <div className="px-5 lg:px-8 py-6 flex flex-col md:flex-row items-center justify-between gap-4">
+        {/* Brand block */}
+        <div className="flex items-center gap-3">
+          <span
+            className="text-white text-sm tracking-[0.3em]"
+            style={{
+              fontFamily: "'Josefin Sans', sans-serif",
+              fontWeight: 600,
+            }}
+          >
+            <span style={{ color: "#4d9aff" }}>M</span>ONARCA
+          </span>
+          <span
+            className="inline-block w-[1px] h-4 bg-white/20"
+            aria-hidden
+          />
+          <span
+            className="text-white/50 text-[0.65rem] tracking-[0.3em] uppercase"
+            style={{ fontWeight: 500 }}
+          >
+            © {new Date().getFullYear()} · 02 Solutions
+          </span>
+        </div>
+
+        {/* Legal links */}
+        <ul className="flex items-center gap-6 text-[0.7rem]">
+          <li>
+            <a
+              href="#"
+              className="text-white/55 hover:text-[#4d9aff] tracking-[0.1em] uppercase transition-colors"
+              style={{ fontWeight: 500 }}
+            >
+              Términos
+            </a>
+          </li>
+          <li>
+            <span className="inline-block w-1 h-1 rounded-full bg-white/25" />
+          </li>
+          <li>
+            <a
+              href="#"
+              className="text-white/55 hover:text-[#4d9aff] tracking-[0.1em] uppercase transition-colors"
+              style={{ fontWeight: 500 }}
+            >
+              Privacidad
+            </a>
+          </li>
+          <li>
+            <span className="inline-block w-1 h-1 rounded-full bg-white/25" />
+          </li>
+          <li>
+            <span
+              className="text-white/35 tracking-[0.1em] uppercase"
+              style={{ fontWeight: 500 }}
+            >
+              All rights reserved
+            </span>
+          </li>
+        </ul>
+      </div>
+    </footer>
+  );
 }
 
 export default Footer;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -7,12 +7,11 @@
  * 16/04/2026 [Rebeca-Davila] Added a button with a toggle function to make the sidebar appear
  */
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useAuth } from "../hooks/auth/authContext";
-import menu from "../assets/menu.svg";
 import { useTranslation } from "react-i18next";
+import { FiMenu, FiLogOut, FiMail, FiShield } from "react-icons/fi";
 import DarkModeButton from "../components/DarkLightButton";
-// import { useApp } from "../hooks/app/appContext";
 
 /**
  * FunctionName: Header, renders a fixed top navbar with the Monarca brand and a user dropdown menu.
@@ -20,88 +19,204 @@ import DarkModeButton from "../components/DarkLightButton";
  * Output: JSX nav element containing the brand name and user profile dropdown.
  */
 function Header({ toggleSidebar }: { toggleSidebar: () => void }) {
-  const { handleLogout ,authState } = useAuth();
+  const { handleLogout, authState } = useAuth();
   const { t, i18n } = useTranslation();
-  // const { pageTitle } = useApp();
-
   const [dropdownOpen, setDropdownOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
 
   const toggleLanguage = () => {
-    const next = i18n.language === 'es' ? 'en' : 'es';
+    const next = i18n.language === "es" ? "en" : "es";
     i18n.changeLanguage(next);
-    localStorage.setItem('language', next);
+    localStorage.setItem("language", next);
   };
 
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setDropdownOpen(false);
+      }
+    };
+    if (dropdownOpen) document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [dropdownOpen]);
+
+  const initials =
+    (authState?.userName?.[0] || "") + (authState?.userLastName?.[0] || "");
+
   return (
-    <nav className="z-50 w-[100%] bg-[var(--dark-blue)] text-[var(--white)]">
-      <div className="px-3 py-5 lg:px-5 lg:pl-3">
-        <div className="flex items-center justify-between">
-          <div className="block md:hidden">
-            <img src={menu} alt="menu" className="w-10 h-10 ml-4 cursor-pointer" 
-            onClick={toggleSidebar}
-             />
-          </div>
-          
-          <div className="flex items-center justify-start rtl:justify-end">
-            <h2 className="uppercase text-3xl pl-10">
-              <span className="text-[var(--ultra-light-blue)]">M</span>onarca
-            </h2>
-          </div>
-          <div className="flex items-center">
-            <div className="flex items-center ms-3 relative">
-              <div className="flex items-center gap-4">
-                <DarkModeButton className="hidden md:flex md:items-center -mt-2" classNameText="#f9fafb"></DarkModeButton>
+    <nav
+      className="relative z-50 w-full"
+      style={{
+        fontFamily: "Montserrat, sans-serif",
+        background:
+          "linear-gradient(135deg, #001d3d 0%, #00296b 60%, #003580 100%)",
+        borderBottom: "1px solid rgba(77, 154, 255, 0.18)",
+      }}
+    >
+      <div className="px-5 lg:px-8 h-[68px] flex items-center justify-between">
+        {/* Mobile menu button */}
+        <button
+          onClick={toggleSidebar}
+          className="md:hidden flex items-center justify-center w-10 h-10 rounded-lg text-white/80 hover:bg-white/10 transition-colors"
+          aria-label="Menu"
+        >
+          <FiMenu size={22} />
+        </button>
+
+        {/* Brand */}
+        <div className="flex items-center gap-3">
+          <span
+            className="text-white text-xl tracking-[0.3em]"
+            style={{ fontFamily: "'Josefin Sans', sans-serif", fontWeight: 600 }}
+          >
+            <span style={{ color: "#4d9aff" }}>M</span>ONARCA
+          </span>
+          <span
+            className="hidden lg:inline-block w-[1px] h-5 bg-white/20 mx-2"
+            aria-hidden
+          />
+          <span
+            className="hidden lg:inline-block text-white/55 text-[0.65rem] tracking-[0.3em] uppercase"
+            style={{ fontWeight: 500 }}
+          >
+            Corporate Travel
+          </span>
+        </div>
+
+        {/* Right controls */}
+        <div className="flex items-center gap-4">
+          <DarkModeButton
+            className="hidden md:flex md:items-center -mt-1"
+            classNameText="#f9fafb"
+          ></DarkModeButton>
+
+          {/* Language switch */}
+          <button
+            type="button"
+            title={i18n.language === "es" ? "Switch to English" : "Cambiar a Español"}
+            onClick={toggleLanguage}
+            className="hidden md:block hover:scale-110 transition-transform"
+          >
+            <img
+              src={i18n.language === "es" ? "/assets/flag_es.svg" : "/assets/flag_gb.svg"}
+              alt={i18n.language === "es" ? "Español" : "English"}
+              className="w-10 h-7 rounded-sm object-cover shadow-sm"
+            />
+          </button>
+
+          {/* User dropdown */}
+          <div className="relative" ref={dropdownRef}>
+            <button
+              type="button"
+              onClick={() => setDropdownOpen(!dropdownOpen)}
+              className="flex items-center gap-3 pl-2 pr-3 py-1.5 rounded-full transition-all duration-200 hover:bg-white/10 group"
+            >
+              <span className="hidden md:flex flex-col items-end leading-tight">
+                <span
+                  className="text-white text-[0.78rem]"
+                  style={{ fontWeight: 600 }}
+                >
+                  {authState?.userName} {authState?.userLastName}
+                </span>
+                <span
+                  className="text-white/50 text-[0.65rem] tracking-[0.15em] uppercase"
+                  style={{ fontWeight: 500 }}
+                >
+                  {authState?.userRole || "Usuario"}
+                </span>
+              </span>
+              <span
+                className="flex items-center justify-center w-10 h-10 rounded-full text-white text-[0.85rem] transition-transform duration-200 group-hover:scale-105"
+                style={{
+                  background: "linear-gradient(135deg, #0466cb 0%, #00296b 100%)",
+                  boxShadow: "0 4px 12px -4px rgba(4, 102, 203, 0.6)",
+                  fontWeight: 700,
+                  letterSpacing: "0.05em",
+                }}
+              >
+                {initials.toUpperCase()}
+              </span>
+            </button>
+
+            {dropdownOpen && (
+              <div
+                className="absolute right-0 mt-3 w-72 rounded-2xl overflow-hidden bg-white border border-gray-200 z-50"
+                style={{
+                  boxShadow: "0 20px 60px -20px rgba(0, 29, 61, 0.35)",
+                  animation: "headerDropFade 0.2s cubic-bezier(0.16, 1, 0.3, 1)",
+                }}
+              >
+                <style>{`
+                  @keyframes headerDropFade {
+                    from { opacity: 0; transform: translateY(-6px); }
+                    to { opacity: 1; transform: translateY(0); }
+                  }
+                `}</style>
+
+                {/* Profile header */}
+                <div
+                  className="px-5 py-5"
+                  style={{
+                    background:
+                      "linear-gradient(135deg, #001d3d 0%, #00296b 100%)",
+                  }}
+                >
+                  <div className="flex items-center gap-3">
+                    <span
+                      className="flex items-center justify-center w-12 h-12 rounded-full text-white text-base flex-shrink-0"
+                      style={{
+                        background:
+                          "linear-gradient(135deg, #4d9aff 0%, #0466cb 100%)",
+                        fontWeight: 700,
+                        letterSpacing: "0.05em",
+                      }}
+                    >
+                      {initials.toUpperCase()}
+                    </span>
+                    <div className="min-w-0">
+                      <p
+                        className="text-white text-sm truncate"
+                        style={{ fontWeight: 600 }}
+                      >
+                        {authState.userName} {authState.userLastName}
+                      </p>
+                      <p
+                        className="text-[#4d9aff] text-[0.65rem] tracking-[0.25em] uppercase mt-0.5"
+                        style={{ fontWeight: 600 }}
+                      >
+                        {authState.userRole || "Usuario"}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Info rows */}
+                <div className="px-5 py-4 border-b border-gray-100">
+                  <div className="flex items-center gap-3 text-xs text-gray-600 mb-2">
+                    <FiMail className="text-gray-400 flex-shrink-0" size={14} />
+                    <span className="truncate">{authState.userEmail}</span>
+                  </div>
+                  <div className="flex items-center gap-3 text-xs text-gray-600">
+                    <FiShield className="text-gray-400 flex-shrink-0" size={14} />
+                    <span className="truncate">{authState.userRole}</span>
+                  </div>
+                </div>
+
+                {/* Logout */}
                 <button
                   type="button"
-                  title={i18n.language === 'es' ? 'Switch to English' : 'Cambiar a Español'}
-                  onClick={toggleLanguage}
-                  className="hidden md:block hover:scale-110 transition-transform mt-1"
+                  onClick={handleLogout}
+                  className="flex items-center gap-3 w-full px-5 py-3.5 text-sm text-[#001D3D] hover:bg-gray-50 transition-colors group/btn"
+                  style={{ fontWeight: 600 }}
                 >
-                  <img
-                    src={i18n.language === 'es' ? '/assets/flag_mx.svg' : '/assets/flag_us.svg'}
-                    alt={i18n.language === 'es' ? 'Español' : 'English'}
-                    className="w-12 h-8 rounded-sm object-cover shadow-sm"
+                  <FiLogOut
+                    className="text-gray-400 group-hover/btn:text-[#0466cb] transition-colors"
+                    size={16}
                   />
-                </button>
-                <button
-                  type="button"
-                  className="flex text-sm bg-[var(--ultra-light-blue)] p-2 rounded-full"
-                  onClick={() => setDropdownOpen(!dropdownOpen)}
-                >
-                  {authState?.userName[0]?.toUpperCase()}{authState?.userLastName[0]?.toUpperCase()}
+                  <span>{t("header.logout")}</span>
                 </button>
               </div>
-              {dropdownOpen &&
-                <div
-                  className="z-50 absolute top-[80%] right-0 min-w-[180px] my-4 text-base list-none bg-[var(--blue)] divide-y divide-[var(--white)] rounded-sm shadow-sm"
-                >
-                  <div className="px-4 py-3">
-                    <p className="text-sm text-[var(--gray)] font-bold whitespace-nowrap overflow-hidden [mask-image:linear-gradient(to_right,black_80%,transparent)] w-[130px]">
-                    {authState.userName} {authState.userLastName}
-                    </p>
-                    <p className="text-sm font-medium text-[var(--gray)] whitespace-nowrap overflow-hidden [mask-image:linear-gradient(to_right,black_80%,transparent)] w-[130px]">
-                     {authState.userEmail}
-
-                    </p>
-                    <p className="text-sm font-medium text-[var(--gray)] whitespace-nowrap overflow-hidden [mask-image:linear-gradient(to_right,black_80%,transparent)] w-[130px]">
-                     {authState.userRole}
-
-                    </p>
-                  </div>
-                  <ul className="py-1">
-                    <li>
-                      <button 
-                        type="button" 
-                        className="block px-4 py-2 text-sm w-full text-[var(--white)] hover:bg-[var(--gray)] hover:text-[var(--blue)]"
-                        onClick={handleLogout}
-                      >
-                        {t('header.logout')}
-                      </button>
-                    </li>
-                  </ul>
-                </div>
-              }
-            </div>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -64,22 +64,12 @@ function Header({ toggleSidebar }: { toggleSidebar: () => void }) {
         </button>
 
         {/* Brand */}
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-3 ml-6 mt-2">
           <span
             className="text-white text-xl tracking-[0.3em]"
             style={{ fontFamily: "'Josefin Sans', sans-serif", fontWeight: 600 }}
           >
             <span style={{ color: "#4d9aff" }}>M</span>ONARCA
-          </span>
-          <span
-            className="hidden lg:inline-block w-[1px] h-5 bg-white/20 mx-2"
-            aria-hidden
-          />
-          <span
-            className="hidden lg:inline-block text-white/55 text-[0.65rem] tracking-[0.3em] uppercase"
-            style={{ fontWeight: 500 }}
-          >
-            Corporate Travel
           </span>
         </div>
 

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -69,7 +69,7 @@ function Layout({ children }: LayoutProps) {
             <Sidebar user={authState}/>
           </div>
 
-          <div className="bg-[var(--color-page-bg)] w-screen px-10 pt-10 flex-1 pb-10 overflow-y-auto min-h-0">{children}</div>
+          <div className="bg-[var(--color-page-bg)] w-screen px-10 pt-10 flex-1 pb-0 overflow-y-auto min-h-0 flex flex-col transition-colors duration-500">{children}</div>
         </div>
         <button
           className="bg-[var(--blue)] text-white px-4 py-2 rounded hover:bg-[var(--dark-blue)] transition-colors text-sm fixed bottom-15 right-4 z-50 flex items-center"

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -48,9 +48,9 @@ function Layout({ children }: LayoutProps) {
   return (
     <div>
       <ToastContainer toastClassName="custom-toast"/>
-      <div className="flex flex-col min-h-screen w-screen">
+      <div className="flex flex-col h-screen w-screen overflow-hidden">
         <Header toggleSidebar={() => setOpenSidebar(prev => !prev)}/>
-        <div className="flex flex-1 relative">
+        <div className="flex flex-1 relative min-h-0">
           {openSidebar && (
             <div
               className="fixed inset-0 bg-black/50 z-30 md:hidden"
@@ -69,7 +69,7 @@ function Layout({ children }: LayoutProps) {
             <Sidebar user={authState}/>
           </div>
 
-          <div className="bg-[var(--color-page-bg)] w-screen px-10 pt-10 flex-1 pb-10">{children}</div>
+          <div className="bg-[var(--color-page-bg)] w-screen px-10 pt-10 flex-1 pb-10 overflow-y-auto min-h-0">{children}</div>
         </div>
         <button
           className="bg-[var(--blue)] text-white px-4 py-2 rounded hover:bg-[var(--dark-blue)] transition-colors text-sm fixed bottom-15 right-4 z-50 flex items-center"

--- a/src/components/Mosaic.tsx
+++ b/src/components/Mosaic.tsx
@@ -6,7 +6,7 @@
  * 06/05/2026 [Sergio Jiawei Xuan] Wrapped card in outer div so driver.js tutorial highlight includes the floating icon.
  */
 
-import { Link } from "react-router-dom"
+import { Link } from "react-router-dom";
 
 interface MosaicProps {
   title: string;
@@ -20,22 +20,45 @@ interface MosaicProps {
  * Input: title - display label; iconPath - path to the icon image; link - navigation route; id - optional HTML id.
  * Output: JSX Link wrapping a styled card element.
  */
-const Mosaic = ({ title, iconPath, link, id}: MosaicProps) => {
-
-    return (
-        <Link to={link} data-cy={`mosaic-${title.toLowerCase().replace(/\s+/g, '-')}`}>
-          <div id={id ? id : undefined} className="pt-8">
-            <div className="relative bg-[var(--color-card-bg)] w-64 h-30 rounded-2xl shadow-md flex items-end justify-center hover:shadow-lg transition-shadow duration-300 ease-in-out">
-              <div className="absolute -top-8 bg-[#2C64C6] w-20 h-20 rounded-2xl flex items-center justify-center shadow-lg">
-                <img src={iconPath} alt={title} />
-              </div>
-              <p className="text-center text-[var(--color-page-text-title)] font-extrabold text-base pb-3 leading-tight px-2">
-                {title}
-              </p>
-            </div>
+const Mosaic = ({ title, iconPath, link, id }: MosaicProps) => {
+  return (
+    <Link
+      to={link}
+      data-cy={`mosaic-${title.toLowerCase().replace(/\s+/g, "-")}`}
+      className="group"
+    >
+      <div id={id ? id : undefined} className="pt-8">
+        <div
+          className="relative bg-[var(--color-card-bg)] border border-[var(--color-border)] w-64 h-36 rounded-2xl flex items-end justify-center transition-all duration-300 ease-out group-hover:-translate-y-1"
+          style={{
+            boxShadow: "0 12px 32px -16px rgba(0, 29, 61, 0.2)",
+            fontFamily: "Montserrat, sans-serif",
+          }}
+        >
+          <div
+            className="absolute -top-8 w-20 h-20 rounded-2xl flex items-center justify-center transition-transform duration-300 ease-out group-hover:scale-105"
+            style={{
+              background: "linear-gradient(135deg, #0466cb 0%, #00296b 100%)",
+              boxShadow: "0 10px 24px -8px rgba(4, 102, 203, 0.45)",
+            }}
+          >
+            <img src={iconPath} alt={title} className="w-12 h-12 object-contain" />
           </div>
-        </Link>
-    )
-}
+          <p
+            className="text-center text-[var(--color-page-text-title)] text-sm pb-4 leading-tight px-3"
+            style={{ fontWeight: 600, letterSpacing: "-0.005em" }}
+          >
+            {title}
+          </p>
+
+          <span
+            className="absolute bottom-0 left-1/2 -translate-x-1/2 h-[2px] w-0 group-hover:w-12 transition-all duration-300"
+            style={{ background: "#4d9aff" }}
+          />
+        </div>
+      </div>
+    </Link>
+  );
+};
 
 export default Mosaic;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -41,9 +41,9 @@ function Sidebar({ user, onNavigate }: { user: AuthState, onNavigate?: () => voi
         <div className="flex items-center bg-[var(--dark-blue)] mb-6 w-[120px] h-[120px] mx-auto p-4 rounded-lg">
             <img src={logo} className="invert mx-auto" alt="Monarca Logo" />
         </div>
-        <div className="flex flex-col items-center justify-center mb-6 text-center">
+        {/* <div className="flex flex-col items-center justify-center mb-6 text-center">
           <p className="text-[var(--color-page-text-title)] font-bold">{user.userName} {user.userLastName} </p>
-        </div>
+        </div> */}
         <ul className="space-y-2 font-medium">
             <SidebarOption
               label={t('sidebar.home')}
@@ -109,7 +109,7 @@ function Sidebar({ user, onNavigate }: { user: AuthState, onNavigate?: () => voi
               className="block md:hidden hover:scale-110 transition-transform mt-3"
             >
               <img
-                src={i18n.language === 'es' ? '/assets/flag_mx.svg' : '/assets/flag_us.svg'}
+                src={i18n.language === 'es' ? '/assets/flag_es.svg' : '/assets/flag_gb.svg'}
                 alt={i18n.language === 'es' ? 'Español' : 'English'}
                 className="w-12 h-8 rounded-sm object-cover shadow-sm"
               />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -35,7 +35,7 @@ function Sidebar({ user, onNavigate }: { user: AuthState, onNavigate?: () => voi
   return (
     <aside
       id="logo-sidebar"
-      className="w-[200px] md:w-[250px] h-full pt-10 bg-[var(--color-card-bg)] text-[var(--black)]"      aria-label="Sidebar"
+      className="w-[200px] md:w-[250px] h-full pt-10 bg-[var(--color-card-bg)] text-[var(--color-page-text)] transition-colors duration-500"      aria-label="Sidebar"
     >
       <div className="h-full px-3 pb-4 overflow-y-auto">
         <div className="flex items-center bg-[var(--dark-blue)] mb-6 w-[120px] h-[120px] mx-auto p-4 rounded-lg">

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -51,7 +51,8 @@
     "email": "Email",
     "password": "Password",
     "forgotPassword": "Forgot your password?",
-    "continue": "Continue"
+    "continue": "Continue",
+    "emailPlaceholder": "user@domain.com"
   },
   "status": {
     "pendingReview": "Pending Review",
@@ -775,5 +776,13 @@
     "yesterday": "Yesterday",
     "last7Days": "Last 7 days",
     "last30Days": "Last 30 days"
+  },
+  "recover": {
+    "eyebrow": "Recovery",
+    "title": "Forgot your password?",
+    "subtitle": "Enter the email address you use to log in to recover your password.",
+    "sending": "Sending",
+    "send": "Send",
+    "haveAccount": "Already have an account?"
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -53,7 +53,8 @@
     "email": "Correo electrónico",
     "password": "Contraseña",
     "forgotPassword": "¿Olvidaste tu contraseña?",
-    "continue": "Continuar"
+    "continue": "Continuar",
+    "emailPlaceholder": "usuario@dominio.com"
   },
   "status": {
     "pendingReview": "Pendiente de Revisión",
@@ -838,5 +839,13 @@
     "yesterday": "Ayer",
     "last7Days": "Últimos 7 días",
     "last30Days": "Últimos 30 días"
+  },
+  "recover": {
+    "eyebrow": "Recuperación",
+    "title": "¿Olvidaste tu contraseña?",
+    "subtitle": "Ingresa tu correo electrónico con el cual inicias sesión para recuperar tu contraseña.",
+    "sending": "Enviando",
+    "send": "Enviar",
+    "haveAccount": "¿Ya tienes cuenta?"
   }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -70,7 +70,7 @@ export const router = createBrowserRouter([
     element: <Login />,
   },
   {
-    path: "/register",
+    path: "/recuperar-contrasena",
     element: <Register />,
   },
   {

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -46,12 +46,8 @@ export const Dashboard = ({ title }: DashboardProps) => {
   return (
     <Tutorial page="dashboard" run={tutorial}>
       <div
-        className="relative -mx-10 -mt-10 -mb-10 px-10 pt-10 pb-16 min-h-full overflow-hidden"
-        style={{
-          fontFamily: "Montserrat, sans-serif",
-          background:
-            "linear-gradient(135deg, #00296b 0%, #0466cb 28%, #4d9aff 55%, #cfe2ff 78%, #ffffff 100%)",
-        }}
+        className="relative -mx-10 -mt-10 px-10 pt-10 pb-16 flex-grow overflow-hidden"
+        style={{ fontFamily: "Montserrat, sans-serif" }}
       >
         <style>{`
           @keyframes fadeUp {
@@ -60,6 +56,17 @@ export const Dashboard = ({ title }: DashboardProps) => {
           }
           .anim-fade { animation: fadeUp 0.7s cubic-bezier(0.16, 1, 0.3, 1) backwards; }
         `}</style>
+
+        {/* Gradient light */}
+        <div
+          className="absolute inset-0 transition-opacity duration-500 dark:opacity-0 pointer-events-none"
+          style={{ background: "linear-gradient(135deg, #00296b 0%, #0466cb 28%, #4d9aff 55%, #cfe2ff 78%, #ddeaff 100%)" }}
+        />
+        {/* Gradient dark */}
+        <div
+          className="absolute inset-0 opacity-0 transition-opacity duration-500 dark:opacity-100 pointer-events-none"
+          style={{ background: "linear-gradient(135deg, #001233 0%, #00204d 28%, #002d6b 55%, #003580 78%, #001a45 100%)" }}
+        />
 
         {/* Wave layers */}
         <svg

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useEffect } from "react";
-import {useApp} from "../hooks/app/appContext";
+import { useApp } from "../hooks/app/appContext";
 import { Permission, useAuth } from "../hooks/auth/authContext";
 import Mosaic from "../components/Mosaic";
 import { Tutorial } from "../components/Tutorial";
@@ -17,7 +17,7 @@ interface DashboardProps {
   title: string;
 }
 
-export const Dashboard = ({title}:DashboardProps) => {
+export const Dashboard = ({ title }: DashboardProps) => {
   const { setPageTitle } = useApp();
   const { authState } = useAuth();
   const { handleVisitPage, tutorial, setTutorial } = useApp();
@@ -43,61 +43,129 @@ export const Dashboard = ({title}:DashboardProps) => {
     handleVisitPage();
   }, []);
 
-
   return (
     <Tutorial page="dashboard" run={tutorial}>
-      <div className="flex flex-col lg:flex-row flex-wrap items-center md:justify-center gap-y-12 gap-x-20 py-10 px-1 ml-0">
-        {!isAdmin && authState.userPermissions.includes("create_request" as Permission) && (
-          <Mosaic title={t('dashboard.createRequest')} iconPath="/assets/crear_solicitud_de_viaje.png" link="/requests/create" id="create-request"/>
-        )}
-        {!isAdmin && authState.userPermissions.includes("view_own_requests" as Permission) && (
-          <Mosaic title={t('dashboard.travelHistory')} iconPath="/assets/historial_de_viajes.png" link="/history" id="history"/>
-        )}
-        {!isAdmin && authState.userPermissions.includes("upload_vouchers" as Permission) && (
-          <Mosaic title={t('dashboard.checkExpenses')} iconPath="/assets/solicitud_de_reembolso.png" link="/refunds" id="upload_vouchers"/>
-        )}
-        {!isAdmin && authState.userPermissions.includes("approve_request" as Permission) && (
-          <Mosaic title={t('dashboard.tripsToApprove')} iconPath="/assets/viajes_por_aprobar.png" link="/approvals" id="approve_request"/>
-        )}
-        {!isAdmin && authState.userPermissions.includes("view_approved_request_history" as Permission) && (
-          <Mosaic title={t('dashboard.approvedHistory')} iconPath="/assets/historial_de_viajes_aprobados.png" link="/history?view=approvals" id="approved_requests"/>
-        )}
-        {!isAdmin && authState.userPermissions.includes("approve_vouchers" as Permission) && (
-          <Mosaic title={t('dashboard.vouchersToApprove')} iconPath="/assets/comprobantes_de_gastos_por_aprobar.png" link="/refunds-review" id="approve_vouchers"/>
-        )}
-        {/* {authState.userPermissions.includes("approve_vouchers" as Permission) && (
-          <Mosaic title="Reembolsos por aprobar" iconPath="/assets/reembolsos_por_aprobar.png" link=""/>
-        )} */}
-        {!isAdmin && authState.userPermissions.includes("check_budgets" as Permission) && (
-          <Mosaic title={t('dashboard.tripsToRegister')} iconPath="/assets/historial_de_reembolsos_aprobados.png" link="/history?view=soi" id="check_budgets"/>
-        )}
-        {!isAdmin && authState.userPermissions.includes("check_budgets" as Permission) && (
-          <Mosaic title={t('dashboard.refundsToRegister')} iconPath="/assets/reembolsos_por_aprobar.png" link="/check-refunds" id="check_refunds"/>
-        )}
-        {!isAdmin && authState.userPermissions.includes("check_budgets" as Permission) && (
-          <Mosaic title={t('dashboard.accountingExport')} iconPath="/assets/historial_de_reembolsos_aprobados.png" link="/accounting/export" id="accounting_export"/>
-        )}
-        {!isAdmin && authState.userPermissions.includes("submit_reservations" as Permission) && (
-          <Mosaic title={t('dashboard.tripsToBook')} iconPath="/assets/viajes_por_reservar.png" link="/bookings" id="bookings"/>
-        )}
-        {/* {authState.userPermissions.includes("submit_reservations" as Permission) && (
-          <Mosaic title="Formulario de ingreso de reservación" iconPath="/assets/formulario_de_ingreso_de_reservacion.png" link=""/>
-        )} */}
-        {!isAdmin && authState.userPermissions.includes("view_travel_agent_history" as Permission) && (
-          <Mosaic title={t('dashboard.reservedHistory')} iconPath="/assets/historial_de_viajes_reservados.png" link="/history" id="reserved_requests"/>
-        )}
-        {authState.isSystemAdmin && (
-          <Mosaic title={t('dashboard.newCompany')} iconPath="/assets/crear_solicitud_de_viaje.png" link="/admin/companies/new" id="create_company"/>
-        )}
-        {(authState.isSystemAdmin || authState.isCompanyAdmin) && (
-          <Mosaic title={t('dashboard.userList')} iconPath="/assets/viajes_por_aprobar.png" link="/admin/users" id="user_list"/>
-        )}
-        {authState.isCompanyAdmin && (
-          <Mosaic title={t('dashboard.rules')} iconPath="/assets/historial_de_viajes.png" link="/admin/rules" id="rules"/>
-        )}
-        {authState.isCompanyAdmin && (
-          <Mosaic title={t('dashboard.notifications')} iconPath="/assets/crear_solicitud_de_viaje.png" link="/admin/notifications" id="notifications"/>
-        )}
+      <div
+        className="relative -mx-10 -mt-10 -mb-10 px-10 pt-10 pb-16 min-h-full overflow-hidden"
+        style={{
+          fontFamily: "Montserrat, sans-serif",
+          background:
+            "linear-gradient(135deg, #00296b 0%, #0466cb 28%, #4d9aff 55%, #cfe2ff 78%, #ffffff 100%)",
+        }}
+      >
+        <style>{`
+          @keyframes fadeUp {
+            from { opacity: 0; transform: translateY(12px); }
+            to { opacity: 1; transform: translateY(0); }
+          }
+          .anim-fade { animation: fadeUp 0.7s cubic-bezier(0.16, 1, 0.3, 1) backwards; }
+        `}</style>
+
+        {/* Wave layers */}
+        <svg
+          className="absolute inset-0 w-full h-full pointer-events-none"
+          preserveAspectRatio="none"
+          viewBox="0 0 1440 900"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M0,520 C240,440 480,640 720,560 C960,480 1200,620 1440,540 L1440,900 L0,900 Z"
+            fill="rgba(255,255,255,0.18)"
+          />
+          <path
+            d="M0,640 C300,560 540,740 800,660 C1060,580 1240,720 1440,660 L1440,900 L0,900 Z"
+            fill="rgba(255,255,255,0.35)"
+          />
+          <path
+            d="M0,760 C260,700 520,840 800,780 C1080,720 1260,820 1440,780 L1440,900 L0,900 Z"
+            fill="rgba(255,255,255,0.6)"
+          />
+          <path
+            d="M0,300 C200,260 380,360 600,320 C820,280 1040,360 1240,310 C1340,290 1400,310 1440,300 L1440,0 L0,0 Z"
+            fill="rgba(255,255,255,0.06)"
+          />
+        </svg>
+
+        {/* Header */}
+        <div
+          className="relative z-10 mb-12 anim-fade"
+          style={{ animationDelay: "0.05s" }}
+        >
+          <span
+            className="text-white/80 text-[0.7rem] tracking-[0.35em] uppercase block mb-3"
+            style={{ fontWeight: 600 }}
+          >
+            {t("dashboard.panelTitle", "Panel principal")}
+          </span>
+          <h1
+            className="text-white text-[2.25rem] lg:text-[2.75rem] leading-[1.05]"
+            style={{
+              fontFamily: "'Josefin Sans', sans-serif",
+              fontWeight: 700,
+              letterSpacing: "-0.02em",
+            }}
+          >
+            {t("dashboard.welcome", "Bienvenido")},{" "}
+            <span style={{ color: "#cfe2ff" }}>
+              {authState?.userName || t("dashboard.traveler", "viajero")}
+            </span>
+          </h1>
+          <p className="text-white/70 text-sm mt-3 max-w-xl">
+            {t("dashboard.subtitle", "Selecciona una sección para continuar con tus gestiones de viaje.")}
+          </p>
+        </div>
+
+        {/* Mosaic grid */}
+        <div
+          className="relative z-10 flex flex-col lg:flex-row flex-wrap items-center md:justify-center gap-y-16 gap-x-10 anim-fade"
+          style={{ animationDelay: "0.2s" }}
+        >
+          {!isAdmin && authState.userPermissions.includes("create_request" as Permission) && (
+            <Mosaic title={t('dashboard.createRequest')} iconPath="/assets/crear_solicitud_de_viaje.png" link="/requests/create" id="create-request"/>
+          )}
+          {!isAdmin && authState.userPermissions.includes("view_own_requests" as Permission) && (
+            <Mosaic title={t('dashboard.travelHistory')} iconPath="/assets/historial_de_viajes.png" link="/history" id="history"/>
+          )}
+          {!isAdmin && authState.userPermissions.includes("upload_vouchers" as Permission) && (
+            <Mosaic title={t('dashboard.checkExpenses')} iconPath="/assets/solicitud_de_reembolso.png" link="/refunds" id="upload_vouchers"/>
+          )}
+          {!isAdmin && authState.userPermissions.includes("approve_request" as Permission) && (
+            <Mosaic title={t('dashboard.tripsToApprove')} iconPath="/assets/viajes_por_aprobar.png" link="/approvals" id="approve_request"/>
+          )}
+          {!isAdmin && authState.userPermissions.includes("view_approved_request_history" as Permission) && (
+            <Mosaic title={t('dashboard.approvedHistory')} iconPath="/assets/historial_de_viajes_aprobados.png" link="/history?view=approvals" id="approved_requests"/>
+          )}
+          {!isAdmin && authState.userPermissions.includes("approve_vouchers" as Permission) && (
+            <Mosaic title={t('dashboard.vouchersToApprove')} iconPath="/assets/comprobantes_de_gastos_por_aprobar.png" link="/refunds-review" id="approve_vouchers"/>
+          )}
+          {!isAdmin && authState.userPermissions.includes("check_budgets" as Permission) && (
+            <Mosaic title={t('dashboard.tripsToRegister')} iconPath="/assets/historial_de_reembolsos_aprobados.png" link="/history?view=soi" id="check_budgets"/>
+          )}
+          {!isAdmin && authState.userPermissions.includes("check_budgets" as Permission) && (
+            <Mosaic title={t('dashboard.refundsToRegister')} iconPath="/assets/reembolsos_por_aprobar.png" link="/check-refunds" id="check_refunds"/>
+          )}
+          {!isAdmin && authState.userPermissions.includes("check_budgets" as Permission) && (
+            <Mosaic title={t('dashboard.accountingExport')} iconPath="/assets/historial_de_reembolsos_aprobados.png" link="/accounting/export" id="accounting_export"/>
+          )}
+          {!isAdmin && authState.userPermissions.includes("submit_reservations" as Permission) && (
+            <Mosaic title={t('dashboard.tripsToBook')} iconPath="/assets/viajes_por_reservar.png" link="/bookings" id="bookings"/>
+          )}
+          {!isAdmin && authState.userPermissions.includes("view_travel_agent_history" as Permission) && (
+            <Mosaic title={t('dashboard.reservedHistory')} iconPath="/assets/historial_de_viajes_reservados.png" link="/history" id="reserved_requests"/>
+          )}
+          {authState.isSystemAdmin && (
+            <Mosaic title={t('dashboard.newCompany')} iconPath="/assets/crear_solicitud_de_viaje.png" link="/admin/companies/new" id="create_company"/>
+          )}
+          {(authState.isSystemAdmin || authState.isCompanyAdmin) && (
+            <Mosaic title={t('dashboard.userList')} iconPath="/assets/viajes_por_aprobar.png" link="/admin/users" id="user_list"/>
+          )}
+          {authState.isCompanyAdmin && (
+            <Mosaic title={t('dashboard.rules')} iconPath="/assets/historial_de_viajes.png" link="/admin/rules" id="rules"/>
+          )}
+          {authState.isCompanyAdmin && (
+            <Mosaic title={t('dashboard.notifications')} iconPath="/assets/crear_solicitud_de_viaje.png" link="/admin/notifications" id="notifications"/>
+          )}
+        </div>
       </div>
     </Tutorial>
   );

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -172,6 +172,7 @@ export const Dashboard = ({ title }: DashboardProps) => {
             <Mosaic title={t('dashboard.companyRequests')} iconPath="/assets/historial_de_viajes.png" link="/admin/company-requests" id="company_requests"/>
           )}
         </div>
+      </div>
     </Tutorial>
   );
 };

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -100,13 +100,20 @@ export default function LoginPage() {
 
   return (
     <div
-      className="relative min-h-screen w-full flex items-center justify-center px-6 py-10 overflow-hidden bg-[var(--color-page-bg)]"
-      style={{
-        fontFamily: "Montserrat, sans-serif",
-        background:
-          "linear-gradient(135deg, #00296b 0%, #0466cb 28%, #4d9aff 55%, #cfe2ff 78%, #ffffff 100%)",
-      }}
+      className="relative min-h-screen w-full flex items-center justify-center px-6 py-10 overflow-hidden"
+      style={{ fontFamily: "Montserrat, sans-serif" }}
     >
+      {/* Gradient light */}
+      <div
+        className="absolute inset-0 transition-opacity duration-500 dark:opacity-0 pointer-events-none"
+        style={{ background: "linear-gradient(135deg, #00296b 0%, #0466cb 28%, #4d9aff 55%, #cfe2ff 78%, #ddeaff 100%)" }}
+      />
+      {/* Gradient dark */}
+      <div
+        className="absolute inset-0 opacity-0 transition-opacity duration-500 dark:opacity-100 pointer-events-none"
+        style={{ background: "linear-gradient(135deg, #001233 0%, #00204d 28%, #002d6b 55%, #003580 78%, #001a45 100%)" }}
+      />
+
       {/* Wave layers */}
       <svg
         className="absolute inset-0 w-full h-full pointer-events-none"
@@ -201,7 +208,7 @@ export default function LoginPage() {
         style={{ animationDelay: "0.05s" }}
       >
         <span
-          className="text-white text-base tracking-[0.3em]"
+          className="text-white text-2xl tracking-[0.3em]"
           style={{ fontFamily: "'Josefin Sans', sans-serif", fontWeight: 600 }}
         >
           <span style={{ color: "#4d9aff" }}>M</span>ONARCA
@@ -230,7 +237,7 @@ export default function LoginPage() {
 
       {/* Card */}
       <div
-        className="relative w-full max-w-[440px] anim-fade z-10 bg-[var(--color-card-bg)] border border-[var(--color-border)] rounded-2xl p-10 lg:p-12"
+        className="relative w-full max-w-[440px] anim-fade z-10 bg-[var(--color-card-bg)] border border-[var(--color-border)] rounded-2xl p-10 lg:p-12 transition-colors duration-500"
         style={{
           animationDelay: "0.15s",
           boxShadow: "0 20px 60px -20px rgba(0, 29, 61, 0.25)",
@@ -273,7 +280,7 @@ export default function LoginPage() {
                 name="email"
                 type="email"
                 required
-                placeholder="tu@empresa.com"
+                placeholder={t("login.emailPlaceholder")}
                 autoComplete="email"
                 className="text-[0.95rem]"
                 value={user.email}
@@ -298,7 +305,7 @@ export default function LoginPage() {
                 {t("login.forgotPassword")}
               </a>
             </div>
-            <div className="field py-2 flex items-center">
+            <div className="field py-2 relative">
               <input
                 onChange={handleChange}
                 name="password"
@@ -306,13 +313,13 @@ export default function LoginPage() {
                 required
                 placeholder="••••••••"
                 autoComplete="current-password"
-                className="text-[0.95rem]"
+                className="text-[0.95rem] pr-8"
                 value={user.password}
               />
               <button
                 type="button"
                 onClick={() => setShowPassword((s) => !s)}
-                className="ml-2 text-gray-400 hover:text-[#001d3d] transition-colors flex-shrink-0"
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-[#001d3d] transition-colors"
                 tabIndex={-1}
                 aria-label={showPassword ? "Ocultar contraseña" : "Mostrar contraseña"}
               >

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -11,6 +11,7 @@ import { useNavigate } from "react-router-dom";
 import { postRequest } from "../utils/apiService";
 import { ToastContainer, toast } from "react-toastify";
 import { useTranslation } from "react-i18next";
+import { FiEye, FiEyeOff, FiArrowRight } from "react-icons/fi";
 import DarkModeButton from "../components/DarkLightButton";
 
 /**
@@ -40,14 +41,13 @@ export default function LoginPage() {
   const navigate = useNavigate();
   const { t, i18n } = useTranslation();
   const toggleLanguage = () => {
-    const next = i18n.language === 'es' ? 'en' : 'es';
+    const next = i18n.language === "es" ? "en" : "es";
     i18n.changeLanguage(next);
-    localStorage.setItem('language', next);
+    localStorage.setItem("language", next);
   };
-  const [user, setUser] = useState<User>({
-    email: "",
-    password: "",
-  });
+  const [user, setUser] = useState<User>({ email: "", password: "" });
+  const [showPassword, setShowPassword] = useState(false);
+  const [loading, setLoading] = useState(false);
 
   /**
    * handleSubmit, validates input fields and performs login request to the API.
@@ -58,17 +58,13 @@ export default function LoginPage() {
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (!user.email || !user.password) {
-      toast.error(t('toast.fillAllFields'), {
+      toast.error(t("toast.fillAllFields"), {
         position: "top-right",
         autoClose: 5000,
-        hideProgressBar: false,
-        closeOnClick: true,
-        pauseOnHover: true,
-        draggable: true,
-        progress: undefined,
       });
       return;
     }
+    setLoading(true);
     // Send request to API
     try {
       const result = await postRequest("/login", { ...user });
@@ -76,27 +72,19 @@ export default function LoginPage() {
         navigate("/dashboard");
       } else {
         console.log(result);
-        toast.error(t('toast.incorrectCredentials'), {
+        toast.error(t("toast.incorrectCredentials"), {
           position: "top-right",
           autoClose: 5000,
-          hideProgressBar: false,
-          closeOnClick: true,
-          pauseOnHover: true,
-          draggable: true,
-          progress: undefined,
         });
       }
     } catch (error) {
       console.log(error);
-      toast.error(t('toast.loginError'), {
+      toast.error(t("toast.loginError"), {
         position: "top-right",
         autoClose: 5000,
-        hideProgressBar: false,
-        closeOnClick: true,
-        pauseOnHover: true,
-        draggable: true,
-        progress: undefined,
       });
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -107,80 +95,267 @@ export default function LoginPage() {
    * Output: void - Updates the "user" state with the new field value.
    */
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setUser({
-      ...user,
-      [event.target.name]: event.target.value,
-    });
+    setUser({ ...user, [event.target.name]: event.target.value });
   };
 
   return (
     <div
-      className="flex flex-col lg:flex-row h-screen w-[100%] bg-[var(--color-page-bg)]"
-      style={{ fontFamily: "Montserrat, sans-serif" }}
+      className="relative min-h-screen w-full flex items-center justify-center px-6 py-10 overflow-hidden bg-[var(--color-page-bg)]"
+      style={{
+        fontFamily: "Montserrat, sans-serif",
+        background:
+          "linear-gradient(135deg, #00296b 0%, #0466cb 28%, #4d9aff 55%, #cfe2ff 78%, #ffffff 100%)",
+      }}
     >
-      <div className="w-[90%] lg:w-[45%] bg-[url('/imageLogin.png')] bg-center bg-cover bg-no-repeat rounded-[15px] h-[10%] lg:h-[95%] m-[2vh]"></div>
-      <div className="w-[100%] lg:w-[55%] flex flex-col justify-center items-center p-12 relative">
-      <div className="absolute top-7 lg:top-8 right-6 lg:right-12 z-50 flex items-center gap-4 lg:gap-4">
-        <DarkModeButton className="flex items-center -mt-4"></DarkModeButton>
+      {/* Wave layers */}
+      <svg
+        className="absolute inset-0 w-full h-full pointer-events-none"
+        preserveAspectRatio="none"
+        viewBox="0 0 1440 900"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M0,520 C240,440 480,640 720,560 C960,480 1200,620 1440,540 L1440,900 L0,900 Z"
+          fill="rgba(255,255,255,0.18)"
+        />
+        <path
+          d="M0,640 C300,560 540,740 800,660 C1060,580 1240,720 1440,660 L1440,900 L0,900 Z"
+          fill="rgba(255,255,255,0.35)"
+        />
+        <path
+          d="M0,760 C260,700 520,840 800,780 C1080,720 1260,820 1440,780 L1440,900 L0,900 Z"
+          fill="rgba(255,255,255,0.6)"
+        />
+        <path
+          d="M0,300 C200,260 380,360 600,320 C820,280 1040,360 1240,310 C1340,290 1400,310 1440,300 L1440,0 L0,0 Z"
+          fill="rgba(255,255,255,0.06)"
+        />
+      </svg>
+      <style>{`
+        @keyframes fadeUp {
+          from { opacity: 0; transform: translateY(12px); }
+          to { opacity: 1; transform: translateY(0); }
+        }
+        @keyframes spin { to { transform: rotate(360deg); } }
+        .anim-fade { animation: fadeUp 0.7s cubic-bezier(0.16, 1, 0.3, 1) backwards; }
+        .field {
+          border-bottom: 1px solid var(--color-border, #e5e7eb);
+          transition: border-color 0.25s ease;
+        }
+        .field:focus-within {
+          border-bottom-color: #001d3d;
+        }
+        .field input {
+          background: transparent;
+          color: var(--color-page-text, #001d3d);
+          outline: none;
+          width: 100%;
+        }
+        .field input::placeholder { color: #9ca3af; }
+        .submit-btn {
+          background: #001d3d;
+          transition: all 0.25s ease;
+        }
+        .submit-btn:hover:not(:disabled) {
+          background: #00296b;
+          transform: translateY(-1px);
+        }
+        .submit-btn:active:not(:disabled) {
+          transform: translateY(0);
+        }
+        .submit-btn:disabled {
+          opacity: 0.6;
+          cursor: wait;
+        }
+        .spinner {
+          width: 16px; height: 16px;
+          border: 2px solid rgba(255,255,255,0.3);
+          border-top-color: white;
+          border-radius: 50%;
+          animation: spin 0.7s linear infinite;
+        }
+        .link-underline {
+          position: relative;
+        }
+        .link-underline::after {
+          content: '';
+          position: absolute;
+          left: 0; right: 0; bottom: -2px;
+          height: 1px;
+          background: currentColor;
+          transform: scaleX(0);
+          transform-origin: right;
+          transition: transform 0.3s ease;
+        }
+        .link-underline:hover::after {
+          transform: scaleX(1);
+          transform-origin: left;
+        }
+      `}</style>
+
+      <ToastContainer toastClassName="custom-toast" />
+
+      {/* Top-left brand */}
+      <div
+        className="absolute top-7 lg:top-8 left-6 lg:left-12 z-50 anim-fade"
+        style={{ animationDelay: "0.05s" }}
+      >
+        <span
+          className="text-white text-base tracking-[0.3em]"
+          style={{ fontFamily: "'Josefin Sans', sans-serif", fontWeight: 600 }}
+        >
+          <span style={{ color: "#4d9aff" }}>M</span>ONARCA
+        </span>
+      </div>
+
+      {/* Top-right controls: dark mode + language */}
+      <div
+        className="absolute top-7 lg:top-8 right-6 lg:right-12 z-50 flex items-center gap-4 anim-fade"
+        style={{ animationDelay: "0.05s" }}
+      >
+        <DarkModeButton className="flex items-center -mt-1"></DarkModeButton>
         <button
           type="button"
-          title={i18n.language === 'es' ? 'Switch to English' : 'Cambiar a Español'}
+          title={i18n.language === "es" ? "Switch to English" : "Cambiar a Español"}
           onClick={toggleLanguage}
-          className="hover:scale-110 transition-transform mt-1"
+          className="hover:scale-110 transition-transform"
         >
           <img
-            src={i18n.language === 'es' ? '/assets/flag_mx.svg' : '/assets/flag_us.svg'}
-            alt={i18n.language === 'es' ? 'Español' : 'English'}
-            className="w-12 h-8 rounded-sm object-cover shadow-sm"
+            src={i18n.language === "es" ? "/assets/flag_es.svg" : "/assets/flag_gb.svg"}
+            alt={i18n.language === "es" ? "Español" : "English"}
+            className="w-10 h-7 rounded-sm object-cover shadow-sm"
           />
         </button>
-        <p
-          className="text-[2rem] lg:text-[2.5rem] dark:text-[var(--color-page-text)]"
-          style={{ fontWeight: 700 }}
-        >
-          <span className="text-[#0466CB]">M</span>ONARCA
-        </p>
       </div>
-        <ToastContainer toastClassName="custom-toast"/>
-        <h1
-          className="text-[2.5rem] lg:text-[3.5rem] text-[var(--color-page-text-title)] dark:text-[var(--color-page-text-title)] text-center mb-8 mt-20"
-          style={{ fontFamily: "'Josefin Sans', sans-serif", fontWeight: 700 }}
-        >
-          {t('login.title')}
-        </h1>
-        <form
-          onSubmit={handleSubmit}
-          className="flex flex-col items-center w-[70%] text-[#001D3D]"
-        >
-          <input
-            onChange={handleChange}
-            name="email"
-            type="email"
-            placeholder={t('login.email')}
-            required
-            className="p-4 w-[100%] bg-[var(--color-card-bg)] border border-[var(--color-border)] text-[var(--color-page-text)] rounded-[0.5rem] bg-[#F0F3F4] shadow-[0_2px_1px_rgba(0,0,0,0.3)] text-[1rem] lg:text-[1.2rem] mb-8"
-          />
-          <input
-            onChange={handleChange}
-            name="password"
-            type="password"
-            placeholder={t('login.password')}
-            required
-            className="p-4 w-[100%] bg-[var(--color-card-bg)] border border-[var(--color-border)] text-[var(--color-page-text)] rounded-[0.5rem] bg-[#F0F3F4] shadow-[0_2px_1px_rgba(0,0,0,0.3)] text-[1rem] lg:text-[1.2rem] mb-4"
-          />
-          <a
-            href="/register"
-            className="text-[1rem] lg:text-[1.2rem] text-center text-[var(--color-page-text-title)] dark:text-[var(--color-page-text-title)] mb-[50px] underline-offset-2 hover:!underline"
+
+      {/* Card */}
+      <div
+        className="relative w-full max-w-[440px] anim-fade z-10 bg-[var(--color-card-bg)] border border-[var(--color-border)] rounded-2xl p-10 lg:p-12"
+        style={{
+          animationDelay: "0.15s",
+          boxShadow: "0 20px 60px -20px rgba(0, 29, 61, 0.25)",
+        }}
+      >
+        <div className="mb-12">
+          <span
+            className="text-[#0466cb] text-[0.7rem] tracking-[0.35em] uppercase block mb-4"
+            style={{ fontWeight: 600 }}
           >
-            {t('login.forgotPassword')}
-          </a>
+            {t("login.welcome", "Bienvenido")}
+          </span>
+          <h1
+            className="text-[var(--color-page-text-title)] text-[2.5rem] leading-[1.05]"
+            style={{
+              fontFamily: "'Josefin Sans', sans-serif",
+              fontWeight: 700,
+              letterSpacing: "-0.02em",
+            }}
+          >
+            {t("login.title")}
+          </h1>
+          <p className="text-gray-500 text-sm mt-3">
+            {t("login.subtitle", "Accede a tu panel de viajes corporativos")}
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="flex flex-col gap-7">
+          {/* Email */}
+          <div>
+            <label
+              className="block text-[0.7rem] tracking-[0.2em] uppercase text-gray-500 mb-2"
+              style={{ fontWeight: 600 }}
+            >
+              {t("login.email")}
+            </label>
+            <div className="field py-2">
+              <input
+                onChange={handleChange}
+                name="email"
+                type="email"
+                required
+                placeholder="tu@empresa.com"
+                autoComplete="email"
+                className="text-[0.95rem]"
+                value={user.email}
+              />
+            </div>
+          </div>
+
+          {/* Password */}
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <label
+                className="text-[0.7rem] tracking-[0.2em] uppercase text-gray-500"
+                style={{ fontWeight: 600 }}
+              >
+                {t("login.password")}
+              </label>
+              <a
+                href="/recuperar-contrasena"
+                className="link-underline text-[0.7rem] tracking-[0.1em] text-[#0466cb]"
+                style={{ fontWeight: 500 }}
+              >
+                {t("login.forgotPassword")}
+              </a>
+            </div>
+            <div className="field py-2 flex items-center">
+              <input
+                onChange={handleChange}
+                name="password"
+                type={showPassword ? "text" : "password"}
+                required
+                placeholder="••••••••"
+                autoComplete="current-password"
+                className="text-[0.95rem]"
+                value={user.password}
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword((s) => !s)}
+                className="ml-2 text-gray-400 hover:text-[#001d3d] transition-colors flex-shrink-0"
+                tabIndex={-1}
+                aria-label={showPassword ? "Ocultar contraseña" : "Mostrar contraseña"}
+              >
+                {showPassword ? (
+                  <FiEyeOff style={{ width: 18, height: 18 }} />
+                ) : (
+                  <FiEye style={{ width: 18, height: 18 }} />
+                )}
+              </button>
+            </div>
+          </div>
+
+          {/* Submit */}
           <button
             type="submit"
-            className="bg-[#00296B] text-white py-4 px-6 rounded-[0.5rem] font-semibold cursor-pointer text-[0.8rem] lg:text-[1rem] text-center w-[70%] lg:w-[30%] hover:bg-[#00509D]"
+            disabled={loading}
+            className="submit-btn text-white rounded-md h-[52px] flex items-center justify-center gap-3 text-[0.85rem] tracking-[0.15em] uppercase mt-4"
+            style={{ fontWeight: 600 }}
           >
-            {t('login.continue')}
+            {loading ? (
+              <>
+                <span className="spinner" />
+                <span>{t("login.verifying", "Verificando")}</span>
+              </>
+            ) : (
+              <>
+                <span>{t("login.continue")}</span>
+                <FiArrowRight style={{ width: 16, height: 16 }} />
+              </>
+            )}
           </button>
         </form>
+
+        {/* <p className="text-center text-gray-400 text-xs mt-8">
+          {t("login.noAccount", "¿Aún no tienes cuenta?")}{" "}
+          <a
+            href="/register"
+            className="link-underline text-[var(--color-page-text-title)]"
+            style={{ fontWeight: 600 }}
+          >
+            {t("login.createOne", "Crea una aquí")}
+          </a>
+        </p> */}
       </div>
     </div>
   );

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -6,65 +6,241 @@
  * 04/05/2026 [Rebeca-Davila] Changed colors and included switch for dark mode
  */
 
-import React from "react";
+import React, { useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { FiArrowRight } from "react-icons/fi";
 import DarkModeButton from "../components/DarkLightButton";
 
-export default function LoginPage() {
+export default function RegisterPage() {
   const navigate = useNavigate();
+  const { t, i18n } = useTranslation();
+  const [loading, setLoading] = useState(false);
+
+  const toggleLanguage = () => {
+    const next = i18n.language === "es" ? "en" : "es";
+    i18n.changeLanguage(next);
+    localStorage.setItem("language", next);
+  };
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    setLoading(true);
     navigate("/dashboard");
   };
 
   return (
     <div
-      className="flex flex-col lg:flex-row h-screen w-[100%] bg-[var(--color-page-bg)]"
-      style={{ fontFamily: "Montserrat, sans-serif" }}
+      className="relative min-h-screen w-full flex items-center justify-center px-6 py-10 overflow-hidden bg-[var(--color-page-bg)]"
+      style={{
+        fontFamily: "Montserrat, sans-serif",
+        background:
+          "linear-gradient(135deg, #00296b 0%, #0466cb 28%, #4d9aff 55%, #cfe2ff 78%, #ffffff 100%)",
+      }}
     >
-      <div className="w-[90%] lg:w-[45%] bg-[url('/imageLogin.png')] bg-center bg-cover bg-no-repeat rounded-[15px] h-[10%] lg:h-[95%] m-[2vh]"></div>
-      <div className="w-[100%] lg:w-[55%] flex flex-col justify-center items-center p-12 relative">
-        <DarkModeButton className="items-center absolute top-7 lg:top-8 right-60 lg:right-75 z-50"></DarkModeButton>
-        <p
-          className="text-[2rem] lg:text-[2.5rem] absolute top-8 right-12 dark:text-[var(--color-page-text)]"
-          style={{ fontWeight: 700 }}
-        >
-          <span className="text-[#0466CB]">M</span>ONARCA
-        </p>
-        <h1
-          className="text-[2.5rem] lg:text-[3.5rem] text-[var(--color-page-text-title)] dark:text-[var(--color-page-text-title)] text-center mb-8 mt-20"
-          style={{ fontFamily: "'Josefin Sans', sans-serif", fontWeight: 700 }}
-        >
-          ¿Olvidaste tu contraseña?
-        </h1>
+      {/* Wave layers */}
+      <svg
+        className="absolute inset-0 w-full h-full pointer-events-none"
+        preserveAspectRatio="none"
+        viewBox="0 0 1440 900"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M0,520 C240,440 480,640 720,560 C960,480 1200,620 1440,540 L1440,900 L0,900 Z"
+          fill="rgba(255,255,255,0.18)"
+        />
+        <path
+          d="M0,640 C300,560 540,740 800,660 C1060,580 1240,720 1440,660 L1440,900 L0,900 Z"
+          fill="rgba(255,255,255,0.35)"
+        />
+        <path
+          d="M0,760 C260,700 520,840 800,780 C1080,720 1260,820 1440,780 L1440,900 L0,900 Z"
+          fill="rgba(255,255,255,0.6)"
+        />
+        <path
+          d="M0,300 C200,260 380,360 600,320 C820,280 1040,360 1240,310 C1340,290 1400,310 1440,300 L1440,0 L0,0 Z"
+          fill="rgba(255,255,255,0.06)"
+        />
+      </svg>
+      <style>{`
+        @keyframes fadeUp {
+          from { opacity: 0; transform: translateY(12px); }
+          to { opacity: 1; transform: translateY(0); }
+        }
+        @keyframes spin { to { transform: rotate(360deg); } }
+        .anim-fade { animation: fadeUp 0.7s cubic-bezier(0.16, 1, 0.3, 1) backwards; }
+        .field {
+          border-bottom: 1px solid var(--color-border, #e5e7eb);
+          transition: border-color 0.25s ease;
+        }
+        .field:focus-within {
+          border-bottom-color: #001d3d;
+        }
+        .field input {
+          background: transparent;
+          color: var(--color-page-text, #001d3d);
+          outline: none;
+          width: 100%;
+        }
+        .field input::placeholder { color: #9ca3af; }
+        .submit-btn {
+          background: #001d3d;
+          transition: all 0.25s ease;
+        }
+        .submit-btn:hover:not(:disabled) {
+          background: #00296b;
+          transform: translateY(-1px);
+        }
+        .submit-btn:active:not(:disabled) {
+          transform: translateY(0);
+        }
+        .submit-btn:disabled {
+          opacity: 0.6;
+          cursor: wait;
+        }
+        .spinner {
+          width: 16px; height: 16px;
+          border: 2px solid rgba(255,255,255,0.3);
+          border-top-color: white;
+          border-radius: 50%;
+          animation: spin 0.7s linear infinite;
+        }
+        .link-underline {
+          position: relative;
+        }
+        .link-underline::after {
+          content: '';
+          position: absolute;
+          left: 0; right: 0; bottom: -2px;
+          height: 1px;
+          background: currentColor;
+          transform: scaleX(0);
+          transform-origin: right;
+          transition: transform 0.3s ease;
+        }
+        .link-underline:hover::after {
+          transform: scaleX(1);
+          transform-origin: left;
+        }
+      `}</style>
 
-        <form onSubmit={handleSubmit} className="flex flex-col gap-4 max-w-md items-center">
-          <h3 className="text-[var(--color-page-text-title)] dark:text-[var(--color-page-text-title)] mb-6 text-lg font-medium">
-            Ingresa tu correo electrónico con el cual inicias sesión para
-            recuperar tu contraseña.
-          </h3>
-          <input
-            type="email"
-            placeholder="Correo"
-            required
-            className="p-4 w-[100%] border border-[#E0E0E0] rounded-[0.5rem] bg-[#F0F3F4] shadow-[0_2px_1px_rgba(0,0,0,0.3)] text-[1rem] lg:text-[1.2rem] mb-8"
+      {/* Top-right controls: brand + dark mode + language */}
+      <div
+        className="absolute top-7 lg:top-8 left-6 lg:left-12 z-50 anim-fade"
+        style={{ animationDelay: "0.05s" }}
+      >
+        <span
+          className="text-white text-base tracking-[0.3em]"
+          style={{ fontFamily: "'Josefin Sans', sans-serif", fontWeight: 600 }}
+        >
+          <span style={{ color: "#4d9aff" }}>M</span>ONARCA
+        </span>
+      </div>
+
+      <div
+        className="absolute top-7 lg:top-8 right-6 lg:right-12 z-50 flex items-center gap-4 anim-fade"
+        style={{ animationDelay: "0.05s" }}
+      >
+        <DarkModeButton className="flex items-center -mt-1"></DarkModeButton>
+        <button
+          type="button"
+          title={i18n.language === "es" ? "Switch to English" : "Cambiar a Español"}
+          onClick={toggleLanguage}
+          className="hover:scale-110 transition-transform"
+        >
+          <img
+            src={i18n.language === "es" ? "/assets/flag_es.svg" : "/assets/flag_gb.svg"}
+            alt={i18n.language === "es" ? "Español" : "English"}
+            className="w-10 h-7 rounded-sm object-cover shadow-sm"
           />
+        </button>
+      </div>
 
-          <p className="text-[18px] text-center mb-[50px] text-[1rem] lg:text-[1.2rem] dark:text-[var(--color-page-text)]">
-            ¿Ya tienes cuenta?&nbsp;
-            <Link className="!underline font-semibold" to="/">
-              Inicia sesión
-            </Link>
+      {/* Card */}
+      <div
+        className="relative w-full max-w-[440px] anim-fade z-10 bg-[var(--color-card-bg)] border border-[var(--color-border)] rounded-2xl p-10 lg:p-12"
+        style={{
+          animationDelay: "0.15s",
+          boxShadow: "0 20px 60px -20px rgba(0, 29, 61, 0.25)",
+        }}
+      >
+        <div className="mb-12">
+          <span
+            className="text-[#0466cb] text-[0.7rem] tracking-[0.35em] uppercase block mb-4"
+            style={{ fontWeight: 600 }}
+          >
+            {t("recover.eyebrow", "Recuperación")}
+          </span>
+          <h1
+            className="text-[var(--color-page-text-title)] text-[2.5rem] leading-[1.05]"
+            style={{
+              fontFamily: "'Josefin Sans', sans-serif",
+              fontWeight: 700,
+              letterSpacing: "-0.02em",
+            }}
+          >
+            {t("recover.title", "¿Olvidaste tu contraseña?")}
+          </h1>
+          <p className="text-gray-500 text-sm mt-3">
+            {t(
+              "recover.subtitle",
+              "Ingresa tu correo electrónico con el cual inicias sesión para recuperar tu contraseña."
+            )}
           </p>
+        </div>
 
+        <form onSubmit={handleSubmit} className="flex flex-col gap-7">
+          {/* Email */}
+          <div>
+            <label
+              className="block text-[0.7rem] tracking-[0.2em] uppercase text-gray-500 mb-2"
+              style={{ fontWeight: 600 }}
+            >
+              {t("login.email", "Correo")}
+            </label>
+            <div className="field py-2">
+              <input
+                name="email"
+                type="email"
+                required
+                placeholder="tu@empresa.com"
+                autoComplete="email"
+                className="text-[0.95rem]"
+              />
+            </div>
+          </div>
+
+          {/* Submit */}
           <button
             type="submit"
-            className="bg-[#00296B] text-white py-4 px-6 rounded-[0.5rem] font-semibold cursor-pointer text-[0.9rem] lg:text-[1rem] text-center w-[50%] lg:w-[30%] hover:bg-[#00509D]"
+            disabled={loading}
+            className="submit-btn text-white rounded-md h-[52px] flex items-center justify-center gap-3 text-[0.85rem] tracking-[0.15em] uppercase mt-4"
+            style={{ fontWeight: 600 }}
           >
-            Enviar
+            {loading ? (
+              <>
+                <span className="spinner" />
+                <span>{t("recover.sending", "Enviando")}</span>
+              </>
+            ) : (
+              <>
+                <span>{t("recover.send", "Enviar")}</span>
+                <FiArrowRight style={{ width: 16, height: 16 }} />
+              </>
+            )}
           </button>
         </form>
+
+        <p className="text-center text-gray-400 text-xs mt-8">
+          {t("recover.haveAccount", "¿Ya tienes cuenta?")}{" "}
+          <Link
+            to="/"
+            className="link-underline text-[var(--color-page-text-title)]"
+            style={{ fontWeight: 600 }}
+          >
+            {t("login.signIn", "Inicia sesión")}
+          </Link>
+        </p>
       </div>
     </div>
   );

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -31,13 +31,20 @@ export default function RegisterPage() {
 
   return (
     <div
-      className="relative min-h-screen w-full flex items-center justify-center px-6 py-10 overflow-hidden bg-[var(--color-page-bg)]"
-      style={{
-        fontFamily: "Montserrat, sans-serif",
-        background:
-          "linear-gradient(135deg, #00296b 0%, #0466cb 28%, #4d9aff 55%, #cfe2ff 78%, #ffffff 100%)",
-      }}
+      className="relative min-h-screen w-full flex items-center justify-center px-6 py-10 overflow-hidden"
+      style={{ fontFamily: "Montserrat, sans-serif" }}
     >
+      {/* Gradient light */}
+      <div
+        className="absolute inset-0 transition-opacity duration-500 dark:opacity-0 pointer-events-none"
+        style={{ background: "linear-gradient(135deg, #00296b 0%, #0466cb 28%, #4d9aff 55%, #cfe2ff 78%, #ddeaff 100%)" }}
+      />
+      {/* Gradient dark */}
+      <div
+        className="absolute inset-0 opacity-0 transition-opacity duration-500 dark:opacity-100 pointer-events-none"
+        style={{ background: "linear-gradient(135deg, #001233 0%, #00204d 28%, #002d6b 55%, #003580 78%, #001a45 100%)" }}
+      />
+
       {/* Wave layers */}
       <svg
         className="absolute inset-0 w-full h-full pointer-events-none"
@@ -130,7 +137,7 @@ export default function RegisterPage() {
         style={{ animationDelay: "0.05s" }}
       >
         <span
-          className="text-white text-base tracking-[0.3em]"
+          className="text-white text-2xl tracking-[0.3em]"
           style={{ fontFamily: "'Josefin Sans', sans-serif", fontWeight: 600 }}
         >
           <span style={{ color: "#4d9aff" }}>M</span>ONARCA
@@ -158,7 +165,7 @@ export default function RegisterPage() {
 
       {/* Card */}
       <div
-        className="relative w-full max-w-[440px] anim-fade z-10 bg-[var(--color-card-bg)] border border-[var(--color-border)] rounded-2xl p-10 lg:p-12"
+        className="relative w-full max-w-[440px] anim-fade z-10 bg-[var(--color-card-bg)] border border-[var(--color-border)] rounded-2xl p-10 lg:p-12 transition-colors duration-500"
         style={{
           animationDelay: "0.15s",
           boxShadow: "0 20px 60px -20px rgba(0, 29, 61, 0.25)",
@@ -203,7 +210,7 @@ export default function RegisterPage() {
                 name="email"
                 type="email"
                 required
-                placeholder="tu@empresa.com"
+                placeholder={t("login.emailPlaceholder")}
                 autoComplete="email"
                 className="text-[0.95rem]"
               />


### PR DESCRIPTION
## Summary

Visual redesign of the authentication screens and the app shell, fully respecting dark mode and i18n.

### Changes
- **Login** and **Register** (password recovery): new design with gradient background, SVG waves, centered card, show-password toggle, loading spinner and entrance animations.
- **Header**: gradient, redesigned user dropdown using `react-icons`, integrated with dark mode and the language switch.
- **Mosaic** and **Footer**: updated styles honoring the theme variables (dark mode).
- **Language flags** changed from Mexico/US to **Spain** (es) and **United Kingdom** (gb).
- **Layout**: fixed header and footer, with internal scrolling only on the content area (footer always visible without a global scroll).
- **Dark mode**: gray tones adjusted (less pure black).
- **Route** `/register` renamed to `/recuperar-contrasena`.
- Tests updated accordingly.

### Branding
- The MONARCA logo moved to the top-left on the login and recovery screens.