### PR TITLE
fix(ui): layout, login, dark mode, header, request form and refresh button improvements

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -75,6 +75,11 @@ a {
   text-decoration: none;
 }
 
+.theme-transitioning,
+.theme-transitioning * {
+  transition: background-color 500ms ease, color 500ms ease, border-color 500ms ease, fill 500ms ease !important;
+}
+
 /* img {
   width: 100%;
   height: auto;

--- a/src/components/DarkLightButton.tsx
+++ b/src/components/DarkLightButton.tsx
@@ -1,13 +1,14 @@
 /**
  * FileName: DarkLightButton.tsx
- * Description: Renders a toggle switch for switching between dark and light themes, with state persistence using localStorage.
+ * Description: Renders a pill-shaped toggle switch for switching between dark and light themes,
+ *              showing sun/moon icons with state persistence via localStorage.
  * Authors: Debug Studio
  * Last Modification made:
- * 03/06/2026 [Nicolas Quintana] Added documentation for maintainability and the DarkModeButton component and its functions.
+ * 04/06/2026 [Sergio Jiawei Xuan] Redesigned toggle as a pill switch with sun/moon icons and smooth 500ms transition.
  */
 
-import Switch from "./ui/Switch";
 import { useEffect, useState } from "react";
+import { FiSun, FiMoon } from "react-icons/fi";
 import { useTranslation } from "react-i18next";
 
 interface Props {
@@ -15,40 +16,53 @@ interface Props {
   classNameText?: string;
 }
 
-/**
- * FunctionName: DarkModeButton, renders a toggle switch for switching between dark and light themes.
- * Input:
- * - className (string): Additional CSS classes for the container.
- * - classNameText (string): Additional CSS classes for the text label.
- * Output: JSX.Element - The dark mode toggle button component.
- */
-export default function DarkModeButton({ className = "", classNameText = ""}: Props) {
+export default function DarkModeButton({ className = "" }: Props) {
   const [isDark, setIsDark] = useState(false);
   const { t } = useTranslation();
 
   useEffect(() => {
-    const savedTheme = localStorage.getItem("theme");
-    const darkEnabled = savedTheme === "dark";
-
-    document.documentElement.classList.toggle("dark", darkEnabled);
-    setIsDark(darkEnabled);
+    const saved = localStorage.getItem("theme");
+    const dark = saved === "dark";
+    document.documentElement.classList.toggle("dark", dark);
+    setIsDark(dark);
   }, []);
 
-  const handleThemeChange = (value: boolean) => {
-    document.documentElement.classList.toggle("dark", value);
-    localStorage.setItem("theme", value ? "dark" : "light");
-    setIsDark(value);
+  const handleToggle = () => {
+    const next = !isDark;
+    document.documentElement.classList.add("theme-transitioning");
+    document.documentElement.classList.toggle("dark", next);
+    localStorage.setItem("theme", next ? "dark" : "light");
+    setIsDark(next);
+    setTimeout(() => {
+      document.documentElement.classList.remove("theme-transitioning");
+    }, 500);
   };
 
   return (
-    <div className={`flex flex-col gap-1 w-[5rem] items-center ${className}`}>
-      <span className="whitespace-nowrap" style={{fontSize: '13px', fontWeight: 'bold', color: classNameText || '#ffffff'}}>{isDark ? t('theme.dark') : t('theme.light')}</span>
-      <Switch
-      checked={isDark}
-      onChange={handleThemeChange}
-      srLabel="Cambiar modo oscuro"
-      className={`bg-gray-300 data-[checked]:bg-[#0a2cc0]`}
-      />
-    </div>
+    <button
+      type="button"
+      role="switch"
+      aria-checked={isDark}
+      onClick={handleToggle}
+      aria-label={isDark ? t("theme.dark") : t("theme.light")}
+      title={isDark ? t("theme.dark") : t("theme.light")}
+      className={`relative flex items-center h-7 w-12 rounded-full p-0.5 transition-all duration-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/50 hover:brightness-125 hover:scale-105 ${className}`}
+      style={{
+        background: isDark
+          ? "rgba(77, 154, 255, 0.45)"
+          : "rgba(255, 255, 255, 0.25)",
+      }}
+    >
+      <span
+        className="flex items-center justify-center w-6 h-6 rounded-full bg-white shadow-sm transition-transform duration-500"
+        style={{ transform: isDark ? "translateX(20px)" : "translateX(0px)" }}
+      >
+        {isDark ? (
+          <FiMoon size={13} style={{ color: "#003580" }} />
+        ) : (
+          <FiSun size={13} style={{ color: "#f59e0b" }} />
+        )}
+      </span>
+    </button>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,13 +4,13 @@
  *              and a dropdown with user info and logout option.
  * Authors: Original Moncarca team
  * Last Modification made:
- * 16/04/2026 [Rebeca-Davila] Added a button with a toggle function to make the sidebar appear
+ * 04/06/2026 [Sergio Jiawei Xuan] Removed role display from user dropdown.
  */
 
 import { useEffect, useRef, useState } from "react";
 import { useAuth } from "../hooks/auth/authContext";
 import { useTranslation } from "react-i18next";
-import { FiMenu, FiLogOut, FiMail, FiShield } from "react-icons/fi";
+import { FiMenu, FiLogOut, FiMail } from "react-icons/fi";
 import DarkModeButton from "../components/DarkLightButton";
 
 /**
@@ -108,12 +108,6 @@ function Header({ toggleSidebar }: { toggleSidebar: () => void }) {
                 >
                   {authState?.userName} {authState?.userLastName}
                 </span>
-                <span
-                  className="text-white/50 text-[0.65rem] tracking-[0.15em] uppercase"
-                  style={{ fontWeight: 500 }}
-                >
-                  {authState?.userRole || "Usuario"}
-                </span>
               </span>
               <span
                 className="flex items-center justify-center w-10 h-10 rounded-full text-white text-[0.85rem] transition-transform duration-200 group-hover:scale-105"
@@ -170,12 +164,6 @@ function Header({ toggleSidebar }: { toggleSidebar: () => void }) {
                       >
                         {authState.userName} {authState.userLastName}
                       </p>
-                      <p
-                        className="text-[#4d9aff] text-[0.65rem] tracking-[0.25em] uppercase mt-0.5"
-                        style={{ fontWeight: 600 }}
-                      >
-                        {authState.userRole || "Usuario"}
-                      </p>
                     </div>
                   </div>
                 </div>
@@ -185,10 +173,6 @@ function Header({ toggleSidebar }: { toggleSidebar: () => void }) {
                   <div className="flex items-center gap-3 text-xs text-gray-600 mb-2">
                     <FiMail className="text-gray-400 flex-shrink-0" size={14} />
                     <span className="truncate">{authState.userEmail}</span>
-                  </div>
-                  <div className="flex items-center gap-3 text-xs text-gray-600">
-                    <FiShield className="text-gray-400 flex-shrink-0" size={14} />
-                    <span className="truncate">{authState.userRole}</span>
                   </div>
                 </div>
 

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -4,7 +4,7 @@
  *              Footer, toast notifications, and a floating Tutorial trigger button around page content.
  * Authors: Original Moncarca team
  * Last Modification made:
- * 04/05/2026 [Rebeca-Davila] Changed colors for dark mode
+ * 04/06/2026 [Sergio Jiawei Xuan] Removed redundant flex-col and transition-colors from main content container.
  */
 
 import React, {useState} from 'react';
@@ -69,7 +69,7 @@ function Layout({ children }: LayoutProps) {
             <Sidebar user={authState}/>
           </div>
 
-          <div className="bg-[var(--color-page-bg)] w-screen px-10 pt-10 flex-1 pb-0 overflow-y-auto min-h-0 flex flex-col transition-colors duration-500">{children}</div>
+          <div className="bg-[var(--color-page-bg)] w-screen px-10 pt-10 flex-1 pb-0 overflow-y-auto min-h-0">{children}</div>
         </div>
         <button
           className="bg-[var(--blue)] text-white px-4 py-2 rounded hover:bg-[var(--dark-blue)] transition-colors text-sm fixed bottom-15 right-4 z-50 flex items-center"

--- a/src/components/RefreshButton.tsx
+++ b/src/components/RefreshButton.tsx
@@ -3,32 +3,48 @@
  * Description: Renders a small icon button used to trigger data refresh actions throughout the application.
  * Authors: Original Moncarca team
  * Last Modification made:
- * 04/05/2026 [Rebeca-Davila] Changed colors for dark mode
+ * 04/06/2026 [Sergio Jiawei Xuan] Added spin animation, 600ms minimum duration, disabled state, and async onClick support.
  */
 
+import { useState } from "react";
 import { MdRefresh } from "react-icons/md";
 
 interface RefreshButtonProps {
-  onClick?: () => void;
+  onClick?: () => void | Promise<void>;
 }
 
 /**
- * FunctionName: RefreshButton, renders a circular refresh icon button with hover styling.
- * Input: onClick — optional callback fired when the button is clicked.
- * Output: JSX button element containing a refresh icon.
+ * FunctionName: RefreshButton, renders a circular refresh icon button with a spin animation while loading.
+ * Input: onClick — optional async callback fired when the button is clicked.
+ * Output: JSX button element with spinning feedback during the refresh.
  */
 const RefreshButton = ({ onClick }: RefreshButtonProps) => {
+  const [spinning, setSpinning] = useState(false);
 
-    return (
-        <button
-            onClick={onClick}
-            className="p-2 bg-[var(--color-page-bg)] rounded-md shadow hover:bg-[var(--color-card-bg)]"
-        >
-            <MdRefresh className="h-6 w-6 text-[var(--color-page-text)]" />
-        </button>
-    )
+  const handleClick = async () => {
+    if (!onClick || spinning) return;
+    setSpinning(true);
+    const start = Date.now();
+    try {
+      await onClick();
+    } finally {
+      const elapsed = Date.now() - start;
+      const remaining = Math.max(0, 600 - elapsed);
+      setTimeout(() => setSpinning(false), remaining);
+    }
+  };
 
-}
-
+  return (
+    <button
+      onClick={handleClick}
+      disabled={spinning}
+      className="p-2 bg-[var(--color-page-bg)] rounded-md shadow hover:bg-[var(--color-card-bg)] disabled:opacity-60 disabled:cursor-not-allowed"
+    >
+      <MdRefresh
+        className={`h-6 w-6 text-[var(--color-page-text)] transition-transform ${spinning ? "animate-spin" : ""}`}
+      />
+    </button>
+  );
+};
 
 export default RefreshButton;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -4,7 +4,7 @@
  *              and permission-based navigation links using SidebarOption items.
  * Authors: Original Moncarca team
  * Last Modification made:
- * 27/05/2026 [Julio Rodriguez]: Moved vouchers-and-refunds link from approve_vouchers (SOI) to approve_request (approver).
+ * 04/06/2026 [Sergio Jiawei Xuan] Removed transition-colors to centralize theme transitions via theme-transitioning class.
  */
 
 // ***************** images *****************
@@ -35,7 +35,7 @@ function Sidebar({ user, onNavigate }: { user: AuthState, onNavigate?: () => voi
   return (
     <aside
       id="logo-sidebar"
-      className="w-[200px] md:w-[250px] h-full pt-10 bg-[var(--color-card-bg)] text-[var(--color-page-text)] transition-colors duration-500"      aria-label="Sidebar"
+      className="w-[200px] md:w-[250px] h-full pt-10 bg-[var(--color-card-bg)] text-[var(--color-page-text)]"      aria-label="Sidebar"
     >
       <div className="h-full px-3 pb-4 overflow-y-auto">
         <div className="flex items-center bg-[var(--dark-blue)] mb-6 w-[120px] h-[120px] mx-auto p-4 rounded-lg">

--- a/src/components/travel-requests/TravelRequestForm.tsx
+++ b/src/components/travel-requests/TravelRequestForm.tsx
@@ -3,7 +3,7 @@
  * Description: Renders the travel request form for create/edit flows, validates inputs, and submits payloads to the API.
  * Authors: Original Monarca team
  * Last Modification made:
- * 03/06/2026 [Nicolas Quintana] Added a brief description to TravelRequestForm and added documentation for the component and its props.
+ * 04/06/2026 [Sergio Jiawei Xuan] Separated destination into cascading country/city dropdowns, matching origin field behavior.
  */
 
 import { Button } from "../ui/Button";
@@ -19,8 +19,10 @@ import {
   Control,
   FieldErrors,
   UseFormRegister,
+  UseFormSetValue,
   Resolver,
 } from "react-hook-form";
+import { Destination } from "../../types/destinations";
 import { useForm, Controller, useFieldArray, useWatch } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -118,8 +120,8 @@ interface DestinationFieldsProps {
   idx: number;
   control: Control<FormValues, unknown, SubmitValues>;
   register: UseFormRegister<FormValues>;
-  destinationOptions: { id: string | number; name: string }[];
-  destinationOptionsById: Map<string, { id: string | number; name: string }>;
+  destinations: Destination[];
+  setValue: UseFormSetValue<FormValues>;
   errors: FieldErrors<FormValues>["requests_destinations"];
   remove: (index: number) => void;
   isLoadingDestinations: boolean;
@@ -127,21 +129,50 @@ interface DestinationFieldsProps {
 
 /**
  * FunctionName: DestinationFields — renders inputs for a single destination leg.
- * Only asks for departure_date (when you leave for this destination).
+ * Country + city are separated like the origin field.
  * arrival_date and stay_days are derived automatically at submit time.
  */
 function DestinationFields({
   idx,
   control,
   register,
-  destinationOptions,
-  destinationOptionsById,
+  destinations,
+  setValue,
   errors,
   remove,
   isLoadingDestinations,
 }: DestinationFieldsProps) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const destinationErrors = errors?.[idx];
+  const [destCountry, setDestCountry] = useState<string>("");
+
+  const destCountryOptions = useMemo(() => {
+    const unique = [...new Set(destinations.map((d) => d.country).filter(Boolean))].sort();
+    return unique.map((c) => ({ id: c, name: translateCountry(c, i18n.language) }));
+  }, [destinations, i18n.language]);
+
+  const destCityOptions = useMemo(() => {
+    const filtered = destCountry
+      ? destinations.filter((d) => d.country === destCountry)
+      : destinations;
+    const cityMap = new Map<string, Option>();
+    for (const d of filtered) {
+      if (d.city && !cityMap.has(d.city)) {
+        cityMap.set(d.city, { id: d.id, name: translateCity(d.city, i18n.language) });
+      }
+    }
+    return Array.from(cityMap.values()).sort((a, b) =>
+      String(a.name).localeCompare(String(b.name), "es", { sensitivity: "base" })
+    );
+  }, [destinations, destCountry, i18n.language]);
+
+  const watchedDest = useWatch({ control, name: `requests_destinations.${idx}.id_destination` });
+  useEffect(() => {
+    if (watchedDest && !destCountry && destinations.length > 0) {
+      const dest = destinations.find((d) => d.id === watchedDest);
+      if (dest?.country) setDestCountry(dest.country);
+    }
+  }, [watchedDest, destinations]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <div className="rounded-md p-4 mb-6 space-y-4 bg-[var(--color-page-bg)] shadow-sm">
@@ -157,10 +188,30 @@ function DestinationFields({
       <div className="grid gap-4 sm:grid-cols-2">
         <div>
           <label
+            htmlFor={`dest-country-${idx}`}
+            className="block mb-2 text-sm font-medium text-[var(--color-page-text)]"
+          >
+            {t('form.destinationCountry')}
+          </label>
+          <SearchableSelect
+            id={`dest-country-${idx}`}
+            options={destCountryOptions}
+            value={destCountry ? destCountryOptions.find((o) => o.id === destCountry) ?? null : null}
+            onChange={(opt) => {
+              setDestCountry(opt ? String(opt.id) : "");
+              setValue(`requests_destinations.${idx}.id_destination`, null);
+            }}
+            isLoading={isLoadingDestinations}
+            placeholder={t('form.destinationCountryPlaceholder')}
+          />
+        </div>
+
+        <div>
+          <label
             htmlFor={`destination-${idx}`}
             className="block mb-2 text-sm font-medium text-[var(--color-page-text)]"
           >
-            {t('form.destination')}
+            {t('form.destinationCity')}
           </label>
           <Controller
             control={control}
@@ -168,15 +219,11 @@ function DestinationFields({
             render={({ field }) => (
               <SearchableSelect
                 id={`destination-${idx}`}
-                options={destinationOptions}
-                value={
-                  field.value
-                    ? destinationOptionsById.get(String(field.value))
-                    : null
-                }
+                options={destCityOptions}
+                value={field.value ? destCityOptions.find((o) => o.id === field.value) ?? null : null}
                 onChange={(opt) => field.onChange(opt ? opt.id : null)}
                 isLoading={isLoadingDestinations}
-                placeholder={t('form.destinationPlaceholder')}
+                placeholder={destCountry ? t('form.destinationPlaceholder') : t('form.destinationCountryFirst')}
               />
             )}
           />
@@ -291,7 +338,7 @@ function TravelRequestForm({ initialData, requestId }: TravelRequestFormProps) {
 
   const currencyOptions = useMemo(() => makeCurrencyOptions(t), [t]);
 
-  const { destinations, destinationOptions, isLoading: isLoadingDestinations } =
+  const { destinations, isLoading: isLoadingDestinations } =
     useDestinations();
 
   const [originCountry, setOriginCountry] = useState<string>("");
@@ -316,13 +363,6 @@ function TravelRequestForm({ initialData, requestId }: TravelRequestFormProps) {
     );
   }, [destinations, originCountry, i18n.language]);
 
-  const destinationOptionsById = useMemo(
-    () =>
-      new Map(
-        destinationOptions.map((option) => [String(option.id), option]),
-      ),
-    [destinationOptions],
-  );
   const { createTravelRequestMutation, isPending: isCreating } =
     useCreateTravelRequest();
   const { updateTravelRequestMutation, isPending: isUpdating } =
@@ -755,8 +795,8 @@ function TravelRequestForm({ initialData, requestId }: TravelRequestFormProps) {
                   idx={idx}
                   control={control}
                   register={register}
-                  destinationOptions={destinationOptions}
-                  destinationOptionsById={destinationOptionsById}
+                  destinations={destinations}
+                  setValue={setValue}
                   errors={errors.requests_destinations}
                   remove={remove}
                   isLoadingDestinations={isLoadingDestinations}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -52,6 +52,7 @@
     "password": "Password",
     "forgotPassword": "Forgot your password?",
     "continue": "Continue",
+    "signIn": "Sign in",
     "emailPlaceholder": "user@domain.com"
   },
   "status": {
@@ -184,6 +185,10 @@
     "originCity": "Origin city",
     "originCityPlaceholder": "Search your city",
     "originCityDisabledPlaceholder": "First select a country",
+    "destinationCountry": "Country",
+    "destinationCountryPlaceholder": "Select a country",
+    "destinationCountryFirst": "First select a country",
+    "destinationCity": "City",
     "advanceMoney": "Advance",
     "currency": "Currency",
     "priority": "Priority",
@@ -258,7 +263,7 @@
     "arrivalDate": "Arrival date:",
     "days": "days",
     "place": "Place:",
-    "flight": "Flight:",
+    "flight": "Flight",
     "details": "Details:",
     "advance": "Advance:",
     "balanceInFavor": "Balance in favor:",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -54,6 +54,7 @@
     "password": "Contraseña",
     "forgotPassword": "¿Olvidaste tu contraseña?",
     "continue": "Continuar",
+    "signIn": "Inicia sesión",
     "emailPlaceholder": "usuario@dominio.com"
   },
   "status": {
@@ -186,6 +187,10 @@
     "originCity": "Ciudad de origen",
     "originCityPlaceholder": "Busca tu ciudad",
     "originCityDisabledPlaceholder": "Primero selecciona un país",
+    "destinationCountry": "País",
+    "destinationCountryPlaceholder": "Selecciona un país",
+    "destinationCountryFirst": "Primero selecciona un país",
+    "destinationCity": "Ciudad",
     "advanceMoney": "Anticipo",
     "currency": "Moneda",
     "priority": "Prioridad",
@@ -260,7 +265,7 @@
     "arrivalDate": "Fecha de llegada:",
     "days": "días",
     "place": "Lugar:",
-    "flight": "Vuelo:",
+    "flight": "Vuelo",
     "details": "Detalles:",
     "advance": "Anticipo:",
     "balanceInFavor": "Saldo a favor:",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,7 +4,7 @@
  * configures React Router routes (public and protected), and sets up TanStack Query provider for server state management.
  * Authors: Original Moncarca team
  * Last Modification made:
- * 02/06/2026 [Nicolas Quintana] Removed comment redundancies.
+ * 04/06/2026 [Sergio Jiawei Xuan] Updated password recovery route to /password-recovery.
  */
 
 import { StrictMode } from "react";
@@ -72,7 +72,7 @@ export const router = createBrowserRouter([
     element: <Login />,
   },
   {
-    path: "/recuperar-contrasena",
+    path: "/password-recovery",
     element: <Register />,
   },
   {

--- a/src/pages/Admin/AdminRules.tsx
+++ b/src/pages/Admin/AdminRules.tsx
@@ -5,9 +5,7 @@
  *              Uses GET/POST/PATCH/DELETE /approval-engine/levels. company_id is derived server-side from JWT.
  * Authors: Original Monarca team
  * Last Modification made:
- * 19/05/2026 [Julio Rodriguez] Replaced hardcoded Spanish strings with i18n t() calls; unified CECO display to show id+name;
- *                              added description and applies_to fields to edit form.
- *                              Added voucher deadline section — PATCH /admin/companies/:id/settings.
+ * 04/06/2026 [Sergio Jiawei Xuan] Added 30-day max validation for voucher deadline; connected RefreshButton onClick.
  */
 import React, { useEffect, useState } from "react";
 import { getRequest, postRequest, patchRequest, deleteRequest } from "../../utils/apiService";
@@ -398,7 +396,7 @@ export default function AdminRules() {
     if (!companyId) return;
     const inputEl = (e.currentTarget.elements.namedItem("voucher_deadline_days")) as HTMLInputElement | null;
     const days = parseInt(inputEl?.value ?? deadlineInput, 10);
-    if (isNaN(days) || days < 1) return;
+    if (isNaN(days) || days < 1 || days > 30) return;
     setSavingDeadline(true);
     setMessage(null);
     try {
@@ -455,7 +453,7 @@ export default function AdminRules() {
               >
                 {showForm ? t('common.cancel') : t('admin.rules.createRule')}
               </button>
-              <RefreshButton />
+              <RefreshButton onClick={fetchRules} />
             </div>
           </div>
         </div>
@@ -480,10 +478,11 @@ export default function AdminRules() {
                     name="voucher_deadline_days"
                     type="number"
                     min={1}
+                    max={30}
                     value={deadlineInput}
                     onChange={(e) => setDeadlineInput(e.target.value)}
                     required
-                    className="w-24"
+                    className="!w-24"
                   />
                   <span className="text-sm text-[var(--color-page-text)]">{t('admin.rules.voucherDeadlineDaysLabel')}</span>
                 </div>

--- a/src/pages/Admin/AdminUsers.tsx
+++ b/src/pages/Admin/AdminUsers.tsx
@@ -5,7 +5,7 @@
  *              because POST /users/import is scoped to the caller's company.
  * Authors: DebugStudio Team
  * Last Modification made:
- * 03/06/2026 [Nicolas Quintana] Removed "Last Modification made" redundancies.
+ * 04/06/2026 [Sergio Jiawei Xuan] Connected RefreshButton onClick to fetchUsers.
  */
 
 import React, { useEffect, useRef, useState } from "react";
@@ -164,7 +164,7 @@ export default function AdminUsers() {
                   {importing ? t('admin.users.importing') : t('admin.users.loadUser')}
                 </button>
               )}
-              <RefreshButton />
+              <RefreshButton onClick={fetchUsers} />
             </div>
           </div>
           <p className="text-sm text-gray-600">

--- a/src/pages/Approvals/Approvals.tsx
+++ b/src/pages/Approvals/Approvals.tsx
@@ -3,9 +3,9 @@
  * Description: Approvals page component, which displays a list of approvals and allows users to approve or reject them.
  * Authors: Original Monarca team
  * Last Modification made:
- * 03/06/2026 [Nicolas Quintana] Added format to the comments and added comment to the ones that didn't have comments.
+ * 04/06/2026 [Sergio Jiawei Xuan] Refactored fetch to useCallback; connected RefreshButton onClick.
  */
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import Table from "../../components/Approvals/Table";
 import { getRequest } from "../../utils/apiService";
 import RefreshButton from "../../components/RefreshButton";
@@ -153,8 +153,7 @@ export const Approvals: React.FC = () => {
    * Input: None 
    * Output: Sets allData and displayData state with formatted travel records
    */
-  useEffect(() => {
-    const fetchTravelRecords = async () => {
+  const fetchTravelRecords = useCallback(async () => {
       try {
         const response = await getRequest("/requests/to-approve");
         const mapped = response.map((trip: any) => {
@@ -182,10 +181,9 @@ export const Approvals: React.FC = () => {
       } catch (error) {
         console.error("Error fetching travel records:", error);
       }
-    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-    fetchTravelRecords();
-  }, []);
+  useEffect(() => { fetchTravelRecords(); }, [fetchTravelRecords]);
 
   /**
    * FunctionName: Tutorial Management
@@ -232,7 +230,7 @@ export const Approvals: React.FC = () => {
             <h2 className="text-2xl font-bold text-[var(--color-page-text-title)]">
               {t('approvals.title')}
             </h2>
-            <RefreshButton />
+            <RefreshButton onClick={fetchTravelRecords} />
           </div>
 
           {/* Filter panel */}

--- a/src/pages/Bookings.tsx
+++ b/src/pages/Bookings.tsx
@@ -5,11 +5,10 @@
  * and provides navigation to the reservation flow.
  * Authors: Original Moncarca team
  * Last Modification made:
- * 20/04/2026 [Diego de la Vega] Added defensive destination/date fallbacks to
- *                             prevent crashes when request data is incomplete.
+ * 04/06/2026 [Sergio Jiawei Xuan] Refactored fetch to useCallback; connected RefreshButton onClick.
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import RefreshButton from "../components/RefreshButton";
 import Table from "../components/Refunds/Table";
 import { getRequest } from "../utils/apiService";
@@ -87,8 +86,7 @@ const Bookings = () => {
    * Input: None.
    * Output: Promise<void> - Updates local state with enriched data.
    */
-  useEffect(() => {
-    const fetchTravelRecords = async () => {
+  const fetchTravelRecords = useCallback(async () => {
       try {
         const response = await getRequest("/requests/to-reserve");
         setDataWithActions(
@@ -122,10 +120,9 @@ const Bookings = () => {
       } catch (error) {
         console.error("Error fetching travel records:", error);
       }
-    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-    fetchTravelRecords();
-  }, []);
+  useEffect(() => { fetchTravelRecords(); }, [fetchTravelRecords]);
 
   /**
    * Tutorial onboarding logic:
@@ -158,7 +155,7 @@ const Bookings = () => {
           <h2 className="text-2xl font-bold text-[var(--color-page-text-title)]">
             {t('bookings.title')}
           </h2>
-          <RefreshButton />
+          <RefreshButton onClick={fetchTravelRecords} />
         </div>
 
         <div id="list_requests">

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -5,7 +5,7 @@
  * tutorial logic for first-time visitors.
  * Authors: Original Moncarca team
  * Last Modification made:
- * 02/06/2026 [Nicolas Quintana] Added a description for the dashboard fucntion.
+ * 04/06/2026 [Sergio Jiawei Xuan] Replaced flex-grow with min-h-[calc(100%+40px)] to restore correct full-height rendering.
  */
 
 import { useEffect } from "react";
@@ -59,7 +59,7 @@ export const Dashboard = ({title}:DashboardProps) => {
   return (
     <Tutorial page="dashboard" run={tutorial}>
       <div
-        className="relative -mx-10 -mt-10 px-10 pt-10 pb-16 flex-grow overflow-hidden"
+        className="relative -mx-10 -mt-10 px-10 pt-10 pb-16 min-h-[calc(100%+40px)] overflow-hidden"
         style={{ fontFamily: "Montserrat, sans-serif" }}
       >
         <style>{`

--- a/src/pages/Historial/Historial.tsx
+++ b/src/pages/Historial/Historial.tsx
@@ -4,11 +4,11 @@
  * It provides a customizable history page with travel records and related actions.
  * Authors: Original Moncarca team
  * Last Modification made:
- * 03/06/2026 [Nicolas Quitnana] Added format to the comments and some fucntions that didn't have comments.
+ * 04/06/2026 [Sergio Jiawei Xuan] Refactored fetch to useCallback; connected RefreshButton onClick.
  */
 
 import Table from "../../components/Refunds/Table";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { getRequest } from "../../utils/apiService";
 import formatDate from "../../utils/formatDate";
 import { Permission, useAuth } from "../../hooks/auth/authContext";
@@ -150,8 +150,7 @@ export const Historial = () => {
    * Input: none
    * Output: void (updates allData and displayData states)
    */
-  useEffect(() => {
-    const fetchTravelRecords = async () => {
+  const fetchTravelRecords = useCallback(async () => {
       try {
         const view = searchParams.get("view");
         const endpoint =
@@ -205,10 +204,9 @@ export const Historial = () => {
       } catch (error) {
         console.error("Error fetching travel records:", error);
       }
-    };
+  }, [searchParams, authState, t]); // eslint-disable-line react-hooks/exhaustive-deps
 
-    fetchTravelRecords();
-  }, [searchParams]);
+  useEffect(() => { fetchTravelRecords(); }, [fetchTravelRecords]);
 
   useEffect(() => {
       const visitedPages = JSON.parse(localStorage.getItem("visitedPages") || "[]");
@@ -276,7 +274,7 @@ export const Historial = () => {
               <h2 className="text-2xl font-bold text-[var(--color-page-text-title)]">
                 {t('historial.title')}
               </h2>
-              <RefreshButton />
+              <RefreshButton onClick={fetchTravelRecords} />
           </div>
 
           {/* Filter panel */}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -3,7 +3,7 @@
  * Description: Login page component that authenticates a user via the backend API and redirects to the dashboard on success. Displays toast notifications for validation and authentication errors.
  * Authors: Original Moncarca team
  * Last Modification made:
- * 02/06/2026 [Nicolas Quintana] Removed comment redundancies.
+ * 04/06/2026 [Sergio Jiawei Xuan] Rounded input borders, dark mode focus ring, and improved eye button styling.
  */
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -145,17 +145,33 @@ export default function LoginPage() {
         @keyframes spin { to { transform: rotate(360deg); } }
         .anim-fade { animation: fadeUp 0.7s cubic-bezier(0.16, 1, 0.3, 1) backwards; }
         .field {
-          border-bottom: 1px solid var(--color-border, #e5e7eb);
+          border: 1px solid var(--color-border, #e5e7eb);
+          border-radius: 0.5rem;
+          padding-left: 0.5rem;
+          padding-right: 0.5rem;
           transition: border-color 0.25s ease;
         }
         .field:focus-within {
-          border-bottom-color: #001d3d;
+          border-color: #001d3d;
+        }
+        .dark .field:focus-within {
+          border-color: #4d9aff;
         }
         .field input {
           background: transparent;
           color: var(--color-page-text, #001d3d);
           outline: none;
+          border: none;
+          box-shadow: none;
           width: 100%;
+          appearance: none;
+          -webkit-appearance: none;
+        }
+        .field input:focus,
+        .field input:focus-visible {
+          outline: none;
+          box-shadow: none;
+          border: none;
         }
         .field input::placeholder { color: #9ca3af; }
         .submit-btn {
@@ -297,7 +313,7 @@ export default function LoginPage() {
                 {t("login.password")}
               </label>
               <a
-                href="/recuperar-contrasena"
+                href="/password-recovery"
                 className="link-underline text-[0.7rem] tracking-[0.1em] text-[#0466cb]"
                 style={{ fontWeight: 500 }}
               >
@@ -312,13 +328,13 @@ export default function LoginPage() {
                 required
                 placeholder="••••••••"
                 autoComplete="current-password"
-                className="text-[0.95rem] pr-8"
+                className="text-[0.95rem] pr-10"
                 value={user.password}
               />
               <button
                 type="button"
                 onClick={() => setShowPassword((s) => !s)}
-                className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-[#001d3d] transition-colors"
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-700 dark:hover:text-gray-100 transition-colors"
                 tabIndex={-1}
                 aria-label={showPassword ? "Ocultar contraseña" : "Mostrar contraseña"}
               >

--- a/src/pages/Refunds/CheckRefunds.tsx
+++ b/src/pages/Refunds/CheckRefunds.tsx
@@ -3,10 +3,10 @@
  * Description: Page component that displays trips with pending refunds to be reviewed by authorized personnel.
  * Authors: Original Monarca team
  * Last Modification made:
- * 03/06/2026 [Nicolas Quintana] Removed comment redundancies and added descriptions to functions that didn't have them.
+ * 04/06/2026 [Sergio Jiawei Xuan] Refactored fetch to useCallback; connected RefreshButton onClick.
  */
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import Table from "../../components/Refunds/Table";
 import { getRequest } from "../../utils/apiService";
 import Button from "../../components/Refunds/Button";
@@ -115,8 +115,7 @@ export const CheckRefunds = () => {
    * Input: None - Uses async function inside useEffect
    * Output: Sets allTrips and displayTrips state with formatted trip data
    */
-  useEffect(() => {
-    const fetchTrips = async () => {
+  const fetchTrips = useCallback(async () => {
       try {
         setLoading(true);
         const response = await getRequest("/requests/refund-to-approve-SOI");
@@ -154,9 +153,9 @@ export const CheckRefunds = () => {
       } finally {
         setLoading(false);
       }
-    };
-    fetchTrips();
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => { fetchTrips(); }, [fetchTrips]);
 
   /**
    * FunctionName: Tutorial Management
@@ -233,7 +232,7 @@ export const CheckRefunds = () => {
             <h2 className="text-2xl font-bold text-[var(--color-page-text-title)]">
                 {t('refunds.vouchersToRegister')}
             </h2>
-            <RefreshButton />
+            <RefreshButton onClick={fetchTrips} />
           </div>
 
           {/* Filter panel */}

--- a/src/pages/Refunds/Refunds.tsx
+++ b/src/pages/Refunds/Refunds.tsx
@@ -3,10 +3,10 @@
  * Description: Component displaying a list of active trips where users can submit expense vouchers.
  * Authors: Original Monarca team
  * Last Modification made:
- * 03/06/2026 [Nicolas Quintana] Added fromat to comments.
+ * 04/06/2026 [Sergio Jiawei Xuan] Refactored fetch to useCallback; connected RefreshButton onClick.
  */
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import Table from "../../components/Refunds/Table";
 import { getRequest } from "../../utils/apiService";
 import Button from "../../components/Refunds/Button";
@@ -75,8 +75,7 @@ export const Refunds = () => {
    * Fetches all trips from the API and filters those with "In Progress" status.
    * Formats the data for display in the table component.
    */
-  useEffect(() => {
-    const fetchTrips = async () => {
+  const fetchTrips = useCallback(async () => {
       try {
         setLoading(true);
 
@@ -111,9 +110,9 @@ export const Refunds = () => {
       } finally {
         setLoading(false);
       }
-    };
-    fetchTrips();
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => { fetchTrips(); }, [fetchTrips]);
 
   /**
    * Check if the user has visited the page before to trigger the tutorial.
@@ -167,7 +166,7 @@ export const Refunds = () => {
               <h2 className="text-2xl font-bold text-[var(--color-page-text-title)]">
                   {t('refunds.checkExpenses')}
               </h2>
-              <RefreshButton />
+              <RefreshButton onClick={fetchTrips} />
             </div>
 
             <div id="list_requests">

--- a/src/pages/Refunds/RefundsReview.tsx
+++ b/src/pages/Refunds/RefundsReview.tsx
@@ -3,10 +3,10 @@
  * Description: Component that displays a table of trip requests awaiting voucher approval by the assigned approver.
  * Authors: Original Monarca team
  * Last Modification made:
- * 03/06/2026 [Nicolas Quintana] Added format to comments.
+ * 04/06/2026 [Sergio Jiawei Xuan] Refactored fetch to useCallback; connected RefreshButton onClick.
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import Table from "../../components/Refunds/Table";
 import RefreshButton from "../../components/RefreshButton";
 import formatDate from "../../utils/formatDate";
@@ -108,8 +108,7 @@ export const RefundsReview = () => {
    * Input: None
    * Output: Promise<void>
    */
-  useEffect(() => {
-    const fetchTrips = async () => {
+  const fetchTrips = useCallback(async () => {
       try {
         setLoading(true);
 
@@ -149,9 +148,9 @@ export const RefundsReview = () => {
       } finally {
         setLoading(false);
       }
-    };
-    fetchTrips();
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => { fetchTrips(); }, [fetchTrips]);
 
   /**
    * FunctionName: Effect to handle tutorial logic and page visit tracking.
@@ -210,7 +209,7 @@ export const RefundsReview = () => {
           <h2 className="text-2xl font-bold text-[var(--color-page-text-title)]">
             {t('refunds.vouchersAndRefunds')}
           </h2>
-          <RefreshButton />
+          <RefreshButton onClick={fetchTrips} />
         </div>
 
         <div id="list_requests">

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -3,8 +3,7 @@
  * Description: Renders the registration page with a form for new users to create an account, including fields for email and password, and links to the login page for existing users.
  * Authors: Original Moncarca team
  * Last Modification made:
- * 04/05/2026 [Rebeca-Davila] Changed colors and included switch for dark mode
- * 02/06/2026 [Nicolas Quintana] Added documentation for the component and handleSubmit function.
+ * 04/06/2026 [Sergio Jiawei Xuan] Rounded input borders and dark mode focus ring, matching Login.tsx.
  */
 
 import React, { useState } from "react";
@@ -95,17 +94,33 @@ export default function RegisterPage() {
         @keyframes spin { to { transform: rotate(360deg); } }
         .anim-fade { animation: fadeUp 0.7s cubic-bezier(0.16, 1, 0.3, 1) backwards; }
         .field {
-          border-bottom: 1px solid var(--color-border, #e5e7eb);
+          border: 1px solid var(--color-border, #e5e7eb);
+          border-radius: 0.5rem;
+          padding-left: 0.5rem;
+          padding-right: 0.5rem;
           transition: border-color 0.25s ease;
         }
         .field:focus-within {
-          border-bottom-color: #001d3d;
+          border-color: #001d3d;
+        }
+        .dark .field:focus-within {
+          border-color: #4d9aff;
         }
         .field input {
           background: transparent;
           color: var(--color-page-text, #001d3d);
           outline: none;
+          border: none;
+          box-shadow: none;
           width: 100%;
+          appearance: none;
+          -webkit-appearance: none;
+        }
+        .field input:focus,
+        .field input:focus-visible {
+          outline: none;
+          box-shadow: none;
+          border: none;
         }
         .field input::placeholder { color: #9ca3af; }
         .submit-btn {

--- a/src/pages/RequestInfo.tsx
+++ b/src/pages/RequestInfo.tsx
@@ -3,7 +3,7 @@
  * Description: Displays travel request details, destination/reservation data, and role-based request actions.
  * Authors: Original Moncarca team
  * Last Modification made:
- * 02/06/2026 [Nicolas Quintana] Removed comment redundancies.
+ * 04/06/2026 [Sergio Jiawei Xuan] Fixed stay_days tag to only render when stay_days > 0.
  */
 
 import React, { useState, useEffect } from 'react';
@@ -652,7 +652,7 @@ const RequestInfo: React.FC = () => {
                     {dest.is_plane_required && (
                       <p id={`plane-${index}`} className='text-sm bg-[var(--blue)] text-[var(--white)] rounded-full px-2 py-1 w-fit'>{t('requestInfo.flight')}</p>
                     )}
-                    {dest.stay_days && (
+                    {dest.stay_days > 0 && (
                       <p id={`stay-days-${index}`} className='text-sm bg-[var(--green)] text-[var(--white)] rounded-full px-2 py-1 w-fit'>{dest.stay_days} {t('requestInfo.days')}</p>
                     )}
 


### PR DESCRIPTION
## Summary

Several UI fixes across the app:

- **Layout / Dashboard**: fixed full-height rendering, removed redundant transitions from content container and sidebar.
- **Login / Register**: rounded input borders, dark mode focus ring, and improved eye button styling.
- **Dark mode toggle**: redesigned as a pill switch with sun/moon icons and smooth 500ms global transition.
- **Header**: removed role display from user dropdown.
- **Routes**: password recovery renamed from `/recuperar-contrasena` to `/password-recovery`.
- **Request form**: destination now uses cascading country → city dropdowns like origin; fixed `stay_days` tag rendering; added missing i18n keys.
- **RefreshButton**: added spin feedback and connected `onClick` to the actual fetch on all pages that use it.

## Test plan
- [x] Dashboard fills full height without gaps in both themes.
- [x] Dark mode toggle animates smoothly and the pill switch renders correctly.
- [x] Login/Register inputs have rounded borders and correct dark mode focus ring.
- [x] User dropdown no longer shows the role.
- [x] `/password-recovery` loads and the login link points to it.
- [x] Destination selector shows country first, then filters cities.
- [x] RefreshButton spins and reloads data; can't be clicked twice at the same time.