### PR TITLE
fix(mobile): improve mobile layout for approvals table and admin rules

### DIFF
--- a/src/components/Approvals/Table.tsx
+++ b/src/components/Approvals/Table.tsx
@@ -95,7 +95,7 @@ const Table: React.FC<TableProps> = ({
   return (
     <div className="relative">
       <div className="overflow-x-auto mb-4">
-        <table className="w-full min-w-[900px] table-fixed text-sm text-left rtl:text-right text-gray-500 dark:text-gray-400 border-separate border-spacing-y-2">
+        <table className="w-full min-w-[1100px] table-fixed text-sm text-left rtl:text-right text-gray-500 dark:text-gray-400 border-separate border-spacing-y-2">
           <thead>
             <tr className="text-xs text-white uppercase bg-[#0a2c6d]">
               {columns.map((column, index) => (

--- a/src/pages/Admin/AdminRules.tsx
+++ b/src/pages/Admin/AdminRules.tsx
@@ -523,7 +523,7 @@ export default function AdminRules() {
           <p className="text-sm text-gray-600">
             {companyId ? `${t('admin.notifications.activeCompany')} ${companyName ?? companyId}` : t('admin.notifications.companyUnavailable')}
           </p>
-          <div className="flex items-center justify-between w-full lg:w-auto gap-3">
+          <div className="flex flex-wrap items-center gap-2 w-full lg:w-auto">
             <select
               value={filterActive}
               onChange={(e) => { setFilterActive(e.target.value as 'all' | 'active' | 'inactive'); setCurrentPage(1); }}
@@ -533,7 +533,7 @@ export default function AdminRules() {
               <option value="active">{t('admin.rules.active')}</option>
               <option value="inactive">{t('admin.rules.inactive')}</option>
             </select>
-            <div className="flex items-center gap-3 shrink-0">
+            <div className="flex items-center gap-2 ml-auto">
               <button
                 id="btn_newRule"
                 onClick={() => { setShowForm(!showForm); setMessage(null); setStagedMainApprovers([]); setApproverMainPickValue(""); }}
@@ -559,7 +559,7 @@ export default function AdminRules() {
             <h3 className="text-base font-semibold text-[var(--color-page-text-title)] mb-3">
               {t('admin.rules.voucherDeadlineTitle')}
             </h3>
-            <form onSubmit={handleSaveDeadline} className="flex items-end gap-4">
+            <form onSubmit={handleSaveDeadline} className="flex flex-col sm:flex-row sm:items-end gap-3">
               <div>
                 <label className={labelClass}>{t('admin.rules.voucherDeadlineDays')}</label>
                 <div className="flex items-center gap-2">
@@ -576,7 +576,7 @@ export default function AdminRules() {
                   <span className="text-sm text-[var(--color-page-text)]">{t('admin.rules.voucherDeadlineDaysLabel')}</span>
                 </div>
               </div>
-              <Button type="submit" disabled={savingDeadline}>
+              <Button type="submit" disabled={savingDeadline} className="self-start sm:self-auto">
                 {savingDeadline ? t('common.saving') : t('admin.rules.voucherDeadlineSave')}
               </Button>
             </form>

--- a/src/pages/Approvals/Approvals.tsx
+++ b/src/pages/Approvals/Approvals.tsx
@@ -140,12 +140,12 @@ export const Approvals: React.FC = () => {
 
   const columns = [
     { key: "status", header: t('approvals.status'), width: "w-52", render: (value: string) => renderStatus(value, t) },
-    { key: "motive", header: t('approvals.trip'), mobileHidden: true },
+    { key: "motive", header: t('approvals.trip') },
     { key: "title", header: t('approvals.motive') },
-    { key: "origin", header: t('approvals.origin'), mobileHidden: true },
+    { key: "origin", header: t('approvals.origin') },
     { key: "departureDate", header: t('approvals.departureDate') },
-    { key: "country", header: t('approvals.departurePlace'), mobileHidden: true },
-    { key: "arrivalDate", header: t('approvals.arrivalDate'), mobileHidden: true },
+    { key: "country", header: t('approvals.departurePlace') },
+    { key: "arrivalDate", header: t('approvals.arrivalDate') },
   ];
 
   // Fetch travel records data from API


### PR DESCRIPTION
## Summary

- Remove `mobileHidden` from all approvals table columns so horizontal scroll handles visibility on small screens instead of hiding columns; increase table min-width from 900px to 1100px
- Prevent the refresh button from overflowing the card boundary on small screens by replacing `shrink-0`/`justify-between` with `flex-wrap` and `ml-auto` on the admin rules action row
- Make the voucher deadline form stack vertically on mobile (`flex-col`) and switch to a row layout on `sm:` and above

## Test plan

- [x] Log in as approver and open "Viajes por aprobar" on a mobile viewport — all columns should be visible via horizontal scroll
- [x] Log in as company admin and open "Reglas" on a narrow mobile viewport — the refresh button should stay inside the card border
- [x] On the same "Reglas" page, verify the "Límite de comprobación de gastos" form stacks the input above the save button on small screens and displays them side by side on wider screens